### PR TITLE
Remove duplicate button from bookmark list

### DIFF
--- a/src/client/components/setting-panel/tree-list.jsx
+++ b/src/client/components/setting-panel/tree-list.jsx
@@ -436,7 +436,7 @@ export default class ItemListTree extends React.PureComponent {
   }
 
   renderDuplicateBtn = (item, isGroup) => {
-    if (!item.id) {
+    if (!item.id || this.props.staticList) {
       return null
     }
     const icon = (


### PR DESCRIPTION
Be a mistake duplicat button disappear in the static list.