### PR TITLE
增加在dosplit显示在选中窗口的识别问题

### DIFF
--- a/src/client/components/session/index.jsx
+++ b/src/client/components/session/index.jsx
@@ -94,7 +94,7 @@ export default class SessionWrapper extends Component {
   }
 
   computeHeight = () => {
-    return this.props.height - tabsHeight
+    return this.props.height - tabsHeight - 32
   }
 
   onChangePane = pane => {
@@ -214,6 +214,7 @@ export default class SessionWrapper extends Component {
                 ...t,
                 activeSplitId,
                 themeConfig,
+                terminalCount: terminals.length,
                 pane,
                 ..._.pick(
                   this,

--- a/src/client/components/setting-panel/tree-list.jsx
+++ b/src/client/components/setting-panel/tree-list.jsx
@@ -436,7 +436,7 @@ export default class ItemListTree extends React.PureComponent {
   }
 
   renderDuplicateBtn = (item, isGroup) => {
-    if (!item.id) {
+    if (!item.id || this.props.staticList) {
       return null
     }
     const icon = (

--- a/src/client/components/terminal/index.jsx
+++ b/src/client/components/terminal/index.jsx
@@ -931,8 +931,13 @@ export default class Term extends Component {
   render () {
     const { id, loading, zmodemTransfer } = this.state
     const { height, width, left, top, position, id: pid } = this.props
+    const isFocus = this.props.id === this.props.activeSplitId
     const cls = classnames('term-wrap', {
       'not-first-term': !!position
+    }, {
+      'term-wrap-focus': isFocus && this.props.terminalCount > 1
+    }, {
+      'term-wrap-blur': !isFocus && this.props.terminalCount > 1
     }, 'tw-' + pid)
     return (
       <div
@@ -957,7 +962,7 @@ export default class Term extends Component {
           style={{
             left: '3px',
             top: '10px',
-            right: 0,
+            right: '7px',
             bottom: '40px'
           }}
         >

--- a/src/client/components/terminal/terminal.styl
+++ b/src/client/components/terminal/terminal.styl
@@ -42,13 +42,10 @@
   position relative
 .term-wrap
   position absolute
-
-.vertical
-  .term-wrap.not-first-term
-    border-top 1px solid #222
-.horizontal
-  .term-wrap.not-first-term
-    border-left 1px solid #222
+.term-wrap-focus
+  box-shadow  inset 0px 0px 3px 0px green
+.term-wrap-blur
+  box-shadow  inset 0px 0px 3px 0px red
 .term-sftp-tabs
   margin-left 5px
 .type-tab


### PR DESCRIPTION
在dosplit显示多个term的时候。有点难区别哪个窗口是当前focus窗口。所以这里增加了一个颜色识别。选中的窗口会有绿色边框。没有的会有红色边框。
<img width="1680" alt="スクリーンショット 2019-11-28 17 50 57" src="https://user-images.githubusercontent.com/12597965/69791415-d7a1d600-1207-11ea-8be7-5ee4167b3e4e.png">
