### PR TITLE
[UI] fix inputOnly label

### DIFF
--- a/src/client/components/quick-commands/quick-commands-form.jsx
+++ b/src/client/components/quick-commands/quick-commands-form.jsx
@@ -95,7 +95,7 @@ class QuickCommandForm extends BookmarkForm {
           )}
         </FormItem>
         <FormItem
-          label={s('inputOnly')}
+          label={t('inputOnly')}
         >
           {getFieldDecorator('inputOnly', {
             initialValue: inputOnly,


### PR DESCRIPTION
This commit fix missing label in quick command form according captures below.

**Before**
![before](https://user-images.githubusercontent.com/16171524/71567097-e7d5fb00-2abc-11ea-90eb-dfd4a42d7d83.png)

**After**
![after](https://user-images.githubusercontent.com/16171524/71567098-eb698200-2abc-11ea-87e3-40262b6305d0.png)
