### PR TITLE
[UI] refactor bookmarks list actions

### DIFF
--- a/src/client/components/setting-panel/tree-list.jsx
+++ b/src/client/components/setting-panel/tree-list.jsx
@@ -272,7 +272,7 @@ export default class ItemListTree extends React.PureComponent {
         <Icon
           type='close'
           title={e('del')}
-          className='pointer list-item-del'
+          className='pointer'
         />
       </Popconfirm>
     )
@@ -310,7 +310,7 @@ export default class ItemListTree extends React.PureComponent {
         type='folder-add'
         title={`${s('new')} ${c('bookmarkCategory')}`}
         onClick={(e) => this.addSubCat(e, item)}
-        className='pointer list-item-edit'
+        className='pointer'
       />
     )
   }
@@ -324,7 +324,7 @@ export default class ItemListTree extends React.PureComponent {
         type='edit'
         title={e('edit')}
         onClick={(e) => this.editItem(e, item)}
-        className='pointer list-item-edit'
+        className='pointer'
       />
     )
   }
@@ -441,7 +441,7 @@ export default class ItemListTree extends React.PureComponent {
       <Icon
         type='copy'
         title={e('duplicate')}
-        className='pointer list-item-edit'
+        className='pointer'
         onClick={(e) => this.duplicateItem(e, item)}
       />
     )
@@ -478,17 +478,21 @@ export default class ItemListTree extends React.PureComponent {
         >
           {title}
         </div>
-        {
-          isGroup
-            ? this.renderGroupBtns(item)
-            : null
-        }
-        {
-          !isGroup
-            ? this.renderDuplicateBtn(item)
-            : null
-        }
-        {this.renderDelBtn(item)}
+        <div
+          className='tree-item-actions'
+        >
+          {
+            isGroup
+              ? this.renderGroupBtns(item)
+              : null
+          }
+          {
+            !isGroup
+              ? this.renderDuplicateBtn(item)
+              : null
+          }
+          {this.renderDelBtn(item)}
+        </div>
       </div>
     )
   }

--- a/src/client/components/setting-panel/tree-list.styl
+++ b/src/client/components/setting-panel/tree-list.styl
@@ -1,7 +1,4 @@
 .tree-list
-  .list-item-edit
-  .list-item-del
-    display none
   .ant-tree li
     > .ant-tree-node-content-wrapper
       width calc(100% - 24px)
@@ -29,26 +26,28 @@
 
 
 .tree-item
-  position relative
+  display flex
   &.is-category
     .tree-item-title
       margin-left 0
       font-weight bold
   &:hover
-    .list-item-del
-    .list-item-edit
-      display inline-block
-      margin-right 5px
-      position static
-      vertical-align middle
+    .tree-item-actions
+      display flex
 .tree-item-title
   margin-left 8px
-  display inline-block
-  vertical-align middle
+  flex 90%
+.tree-item-actions
+  display none
+  align-items center
+  justify-content center
+  flex auto
+  i
+    padding 5px
 
 .model-bookmark-tree-wrap
   .tree-item-title
-    width calc(100% - 45px)
+    width calc(100% - 60px)
   .tree-item
     &.is-category
       .tree-item-title


### PR DESCRIPTION
Hi XUDGONG !

Refactor bookmarks list actions visibility using flexbox + add div wrapper containing all actions instead of each named and separated action.

This fix some icons visibility when over bookmark as you can see below :

**Before**
![before](https://user-images.githubusercontent.com/16171524/71582814-116a4300-2b0c-11ea-9025-4ed75e0eede3.gif)

**After**
![after](https://user-images.githubusercontent.com/16171524/71582821-17602400-2b0c-11ea-8b2e-47daaa1aceab.gif)
