### PR TITLE
[UI] Add collapse/expand actions in bookmarks list

### DIFF
--- a/src/client/components/sidebar/bookmark.jsx
+++ b/src/client/components/sidebar/bookmark.jsx
@@ -40,6 +40,20 @@ export default memo((props) => {
                 onClick={store.onNewSsh}
               />
             </Tooltip>
+            <Tooltip title={c('expandAll')}>
+              <Icon
+                type='arrows-alt'
+                className='font16 mg1x mg2l pointer iblock control-icon icon-do-edit'
+                onClick={store.expandBookmarks}
+              />
+            </Tooltip>
+            <Tooltip title={c('collapseAll')}>
+              <Icon
+                type='shrink'
+                className='font16 mg1x mg2l pointer iblock control-icon icon-do-edit'
+                onClick={store.collapseBookmarks}
+              />
+            </Tooltip>
           </div>
         </div>
       </div>

--- a/src/client/store/index.js
+++ b/src/client/store/index.js
@@ -499,6 +499,18 @@ const store = Subx.create({
     }
   },
 
+  expandBookmarks () {
+    store.setState({
+      openedCategoryIds: store.bookmarkGroups.map(g => g.id)
+    })
+  },
+
+  collapseBookmarks () {
+    store.setState({
+      openedCategoryIds: []
+    })
+  },
+
   setTheme (id) {
     store.config.theme = id
   },


### PR DESCRIPTION
Add actions to collapse or expand in select bookmarks list according requiest on issue #1454 

No _collapse_ and _expand_ icons or equivalent exists in Ant so I used _shrink_ and _vertical-align-middle_

I need to add 2 new translations (_expandAll_ and _collapseAll_) in electerm-locales repos. Will create new PR after this one.

![capture](https://user-images.githubusercontent.com/16171524/71624354-637d9800-2be2-11ea-96b1-26f34826eccc.gif)
