### PR TITLE
fix pressed key checking

### DIFF
--- a/src/client/components/session/index.jsx
+++ b/src/client/components/session/index.jsx
@@ -88,7 +88,7 @@ export default class SessionWrapper extends Component {
     if (!this.isActive()) {
       return
     }
-    if (keyControlPressed(e) && e.code === 'Slash') {
+    if (keyControlPressed(e) && e.key.toLowerCase() === '/') {
       this.doSplit()
     }
   }

--- a/src/client/components/sftp/index.jsx
+++ b/src/client/components/sftp/index.jsx
@@ -371,28 +371,29 @@ export default class Sftp extends Component {
     }
     const { type } = lastClickedFile
     const { inputFocus, onDelete } = this
-    if (keyControlPressed(e) && e.code === 'KeyA' && !inputFocus) {
+    const pressedKey = e.key.toLowerCase()
+    if (keyControlPressed(e) && pressedKey === 'a' && !inputFocus) {
       e.stopPropagation()
       this.selectAll(type, e)
-    } else if (e.code === 'ArrowDown' && !inputFocus) {
+    } else if (pressedKey === 'arrowdown' && !inputFocus) {
       e.stopPropagation()
       this.selectNext(type)
-    } else if (e.code === 'ArrowUp' && !inputFocus) {
+    } else if (pressedKey === 'arrowup' && !inputFocus) {
       e.stopPropagation()
       this.selectPrev(type)
-    } else if (e.code === 'Delete' && !inputFocus) {
+    } else if (pressedKey === 'delete' && !inputFocus) {
       e.stopPropagation()
       this.onDel(type)
-    } else if (e.code === 'Enter' && !inputFocus && !onDelete) {
+    } else if (pressedKey === 'enter' && !inputFocus && !onDelete) {
       e.stopPropagation()
       this.enter(type, e)
-    } else if (keyControlPressed(e) && e.code === 'KeyC' && !inputFocus) {
+    } else if (keyControlPressed(e) && pressedKey === 'c' && !inputFocus) {
       e.stopPropagation()
       this.doCopy(type, e)
-    } else if (keyControlPressed(e) && e.code === 'KeyX' && !inputFocus) {
+    } else if (keyControlPressed(e) && pressedKey === 'x' && !inputFocus) {
       e.stopPropagation()
       this.doCut(type, e)
-    } else if (keyControlPressed(e) && e.code === 'KeyV' && !inputFocus) {
+    } else if (keyControlPressed(e) && pressedKey === 'v' && !inputFocus) {
       e.stopPropagation()
       this.doPaste(type, e)
     } else if (e.code === 'F5') {

--- a/src/client/components/terminal/index.jsx
+++ b/src/client/components/terminal/index.jsx
@@ -217,7 +217,7 @@ export default class Term extends Component {
     if (e.data && e.data.id === this.props.id) {
       e.stopPropagation()
       this.term.selectAll()
-    } else if (keyControlPressed(e) && e.code === 'KeyF') {
+    } else if (keyControlPressed(e) && e.key.toLowerCase() === 'f') {
       e.stopPropagation()
       this.openSearch()
     } else if (

--- a/src/client/store/index.js
+++ b/src/client/store/index.js
@@ -888,7 +888,7 @@ const store = Subx.create({
 
   initShortcuts () {
     window.addEventListener('keydown', e => {
-      if (keyControlPress(e) && e.code === 'KeyW') {
+      if (keyControlPress(e) && e.key.toLowerCase() === 'w') {
         e.stopPropagation()
         store.delTab({
           id: store.currentTabId


### PR DESCRIPTION
Use .key event property instead of .code to avoid differences in keyboard disposition (eg QWERTY vs AZERTY)

Example, the letter W (code = KeyW) on my AZERTY keyboard is letter Z (code KeyZ) on your QWERTY keyboard, and shortcut fail in this case.

This fix check the real _character_ pressed as explained here : https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code