### PR TITLE
fix #1459 Refactor pressed key checking

### DIFF
--- a/src/client/common/key-pressed.js
+++ b/src/client/common/key-pressed.js
@@ -1,0 +1,7 @@
+/**
+ * check if given key is pressed
+ */
+
+export default (e, key) => {
+  return 'key' in e ? e.key.toLowerCase() === key.toLowerCase() : false
+}

--- a/src/client/common/key-shift-pressed.js
+++ b/src/client/common/key-shift-pressed.js
@@ -1,0 +1,7 @@
+/**
+ * check if shift key is pressed
+ */
+
+export default e => {
+  return 'shiftKey' in e ? e.shiftKey : false
+}

--- a/src/client/components/session/index.jsx
+++ b/src/client/components/session/index.jsx
@@ -17,6 +17,7 @@ import {
 } from '../../common/constants'
 import ResizeWrap from '../common/resize-wrap'
 import keyControlPressed from '../../common/key-control-pressed'
+import keyPressed from '../../common/key-pressed'
 import Qm from '../quick-commands/quick-commands-select'
 
 const rebuildPosition = terminals => {
@@ -88,7 +89,7 @@ export default class SessionWrapper extends Component {
     if (!this.isActive()) {
       return
     }
-    if (keyControlPressed(e) && e.code === 'Slash') {
+    if (keyControlPressed(e) && keyPressed(e, '/')) {
       this.doSplit()
     }
   }

--- a/src/client/components/sftp/index.jsx
+++ b/src/client/components/sftp/index.jsx
@@ -27,6 +27,7 @@ import Client from '../../common/sftp'
 import fs from '../../common/fs'
 import ResizeWrap from '../common/resize-wrap'
 import keyControlPressed from '../../common/key-control-pressed'
+import keyPressed from '../../common/key-pressed'
 import ListTable from './list-table'
 import deepCopy from 'json-deep-copy'
 import isValidPath from '../../common/is-valid-path'
@@ -371,31 +372,31 @@ export default class Sftp extends Component {
     }
     const { type } = lastClickedFile
     const { inputFocus, onDelete } = this
-    if (keyControlPressed(e) && e.code === 'KeyA' && !inputFocus) {
+    if (keyControlPressed(e) && keyPressed(e, 'a') && !inputFocus) {
       e.stopPropagation()
       this.selectAll(type, e)
-    } else if (e.code === 'ArrowDown' && !inputFocus) {
+    } else if (keyPressed(e, 'arrowdown') && !inputFocus) {
       e.stopPropagation()
       this.selectNext(type)
-    } else if (e.code === 'ArrowUp' && !inputFocus) {
+    } else if (keyPressed(e, 'arrowup') && !inputFocus) {
       e.stopPropagation()
       this.selectPrev(type)
-    } else if (e.code === 'Delete' && !inputFocus) {
+    } else if (keyPressed(e, 'delete') && !inputFocus) {
       e.stopPropagation()
       this.onDel(type)
-    } else if (e.code === 'Enter' && !inputFocus && !onDelete) {
+    } else if (keyPressed(e, 'enter') && !inputFocus && !onDelete) {
       e.stopPropagation()
       this.enter(type, e)
-    } else if (keyControlPressed(e) && e.code === 'KeyC' && !inputFocus) {
+    } else if (keyControlPressed(e) && keyPressed(e, 'c') && !inputFocus) {
       e.stopPropagation()
       this.doCopy(type, e)
-    } else if (keyControlPressed(e) && e.code === 'KeyX' && !inputFocus) {
+    } else if (keyControlPressed(e) && keyPressed(e, 'x') && !inputFocus) {
       e.stopPropagation()
       this.doCut(type, e)
-    } else if (keyControlPressed(e) && e.code === 'KeyV' && !inputFocus) {
+    } else if (keyControlPressed(e) && keyPressed(e, 'v') && !inputFocus) {
       e.stopPropagation()
       this.doPaste(type, e)
-    } else if (e.code === 'F5') {
+    } else if (keyPressed(e, 'f5')) {
       e.stopPropagation()
       this.onGoto(type)
     }

--- a/src/client/components/terminal/index.jsx
+++ b/src/client/components/terminal/index.jsx
@@ -30,6 +30,8 @@ import * as search from 'xterm/lib/addons/search/search'
 import * as webLinks from 'xterm/lib/addons/webLinks/webLinks'
 import { Zmodem, addonZmodem } from './xterm-zmodem'
 import keyControlPressed from '../../common/key-control-pressed'
+import keyShiftPressed from '../../common/key-shift-pressed'
+import keyPressed from '../../common/key-pressed'
 import { Terminal } from 'xterm'
 
 Terminal.applyAddon(fit)
@@ -195,6 +197,7 @@ export default class Term extends Component {
     const isActiveTerminal = this.props.id === this.props.activeSplitId &&
       this.props.tab.id === this.props.currentTabId &&
       this.props.pane === paneMap.terminal
+
     if (
       e.data &&
       e.data.type === 'focus' &&
@@ -214,16 +217,24 @@ export default class Term extends Component {
       )
       this.term.focus()
     }
-    if (e.data && e.data.id === this.props.id) {
+
+    if (
+      keyControlPressed(e) &&
+      keyShiftPressed(e) &&
+      keyPressed(e, 'c')
+    ) {
+      e.stopPropagation()
+      this.copySelectionToClipboard()
+    } else if (e.data && e.data.id === this.props.id) {
       e.stopPropagation()
       this.term.selectAll()
-    } else if (keyControlPressed(e) && e.code === 'KeyF') {
+    } else if (keyControlPressed(e) && keyPressed(e, 'f')) {
       e.stopPropagation()
       this.openSearch()
     } else if (
-      e.ctrlKey &&
-      e.shiftKey &&
-      e.code === 'Tab'
+      keyControlPressed(e) &&
+      keyPressed(e, 'shift') &&
+      keyPressed(e, 'tab')
     ) {
       e.stopPropagation()
       this.props.store.clickNextTab()
@@ -232,10 +243,14 @@ export default class Term extends Component {
 
   onSelection = () => {
     if (this.props.config.copyWhenSelect) {
-      const txt = this.term.getSelection()
-      if (txt) {
-        copy(txt)
-      }
+      this.copySelectionToClipboard()
+    }
+  }
+
+  copySelectionToClipboard = () => {
+    const txt = this.term.getSelection()
+    if (txt) {
+      copy(txt)
     }
   }
 

--- a/src/client/store/index.js
+++ b/src/client/store/index.js
@@ -26,6 +26,7 @@ import {
 } from '../common/constants'
 import * as terminalThemes from '../common/terminal-theme'
 import keyControlPress from '../common/key-control-pressed'
+import keyPressed from '../common/key-pressed'
 
 const { buildNewTheme } = terminalThemes
 const { getGlobal, _config } = window
@@ -888,7 +889,7 @@ const store = Subx.create({
 
   initShortcuts () {
     window.addEventListener('keydown', e => {
-      if (keyControlPress(e) && e.code === 'KeyW') {
+      if (keyControlPress(e) && keyPressed(e, 'w')) {
         e.stopPropagation()
         store.delTab({
           id: store.currentTabId


### PR DESCRIPTION
Add method to check if shift key is pressed --> src/client/common/key-shift-pressed.js
Add method to check if given key is checked --> src/client/common/key-pressed.js

Use **.key** event property instead of **.code** to avoid differences in keyboard disposition (eg QWERTY vs AZERTY)

Example, the letter W (code = **KeyW**) on my AZERTY keyboard is letter Z (code **KeyZ**) on your QWERTY keyboard, and shortcut fail in this case.

Now we check the real character pressed as explained here : https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code

Also it fix issue #1459 for CTRL + SHIFT + C shortcut to copy selected text in terminal (tested on my side in Linux Mint 19 and Ubuntu 18.04)