### PR TITLE
update README to describe some required libraries to start in dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ npm run lint
 npm run fix
 ```
 
+If you encounter some errors when running ```npm run app``` like ```libatk1.0.so.0: cannot open shared object file``` or ```libgtk-3.so.0: cannot open shared object file``` you need to install some required libraries (example for Ubuntu in WSL 2) :
+
+```
+sudo apt install libatk1.0-0 libatk1.0-dev libatk-bridge2.0-0 libatk-bridge2.0-dev libgtk-3-0 libgtk-3-dev
+```
+
 ## Test
 
 ```bash


### PR DESCRIPTION
Hi @zxdong262 👍 

In my case, on Ubuntu 20.04 (WSL 2) when I tried to start dev environment, I had errors like below : 

```
error while loading shared libraries: libatk-bridge-2.0.so.0: cannot open shared object file
error while loading shared libraries: libgtk-3.so.0: cannot open shared object file
```

I just needed to install some missing and required libraries to be able to start developing.

Packages to install are : 

```
libatk1.0-0 
libatk1.0-dev 
libatk-bridge2.0-0 
libatk-bridge2.0-dev 
libgtk-3-0 
libgtk-3-dev
```

So I add added a quick description about it in README !