### PR TITLE
feat: putty like ssh tunnel destination

### DIFF
--- a/src/app/common/build-ssh-tunnel.js
+++ b/src/app/common/build-ssh-tunnel.js
@@ -2,6 +2,7 @@ exports.buildSshTunnels = function (inst) {
   return [{
     sshTunnel: inst.sshTunnel,
     sshTunnelRemotePort: inst.sshTunnelRemotePort,
-    sshTunnelLocalPort: inst.sshTunnelLocalPort
+    sshTunnelLocalPort: inst.sshTunnelLocalPort,
+    sshTunnelRemoteHost: inst.sshTunnelRemoteHost,
   }]
 }

--- a/src/app/common/build-ssh-tunnel.js
+++ b/src/app/common/build-ssh-tunnel.js
@@ -3,6 +3,6 @@ exports.buildSshTunnels = function (inst) {
     sshTunnel: inst.sshTunnel,
     sshTunnelRemotePort: inst.sshTunnelRemotePort,
     sshTunnelLocalPort: inst.sshTunnelLocalPort,
-    sshTunnelRemoteHost: inst.sshTunnelRemoteHost,
+    sshTunnelRemoteHost: inst.sshTunnelRemoteHost
   }]
 }

--- a/src/client/common/build-ssh-tunnel.js
+++ b/src/client/common/build-ssh-tunnel.js
@@ -2,6 +2,7 @@ export const buildSshTunnels = function (inst) {
   return [{
     sshTunnel: inst.sshTunnel,
     sshTunnelRemotePort: inst.sshTunnelRemotePort,
-    sshTunnelLocalPort: inst.sshTunnelLocalPort
+    sshTunnelLocalPort: inst.sshTunnelLocalPort,
+    sshTunnelRemoteHost: inst.sshTunnelRemoteHost
   }]
 }

--- a/src/client/components/bookmark-form/render-ssh-tunnel.jsx
+++ b/src/client/components/bookmark-form/render-ssh-tunnel.jsx
@@ -1,5 +1,6 @@
 import {
   Form,
+  Input,
   InputNumber,
   Radio,
   Space,
@@ -47,29 +48,46 @@ export default function renderSshTunnel () {
             </RadioButton>
           </RadioGroup>
         </FormItem>
+        <Space.Compact className='mg2x'>
+          <FormItem
+            label={e('destination')}
+            name={[field.name, 'sshTunnelRemoteHost']}
+            initialValue={'127.0.0.1'}
+            required
+          >
+            <Input
+              className='compact-input'
+              placeholder={e('host')}
+            />
+          </FormItem>
+          <FormItem
+            label=''
+            name={[field.name, 'sshTunnelRemotePort']}
+            initialValue={22}
+            required
+          >
+            <InputNumber
+              min={1}
+              max={65535}
+              // addonBefore={e('remotePort')}
+              className='compact-input'
+              placeholder={e('port')}
+            />
+          </FormItem>
+        </Space.Compact>
         <FormItem
-          label=''
-          name={[field.name, 'sshTunnelRemotePort']}
-          required
-        >
-          <InputNumber
-            min={1}
-            max={65535}
-            addonBefore={e('remotePort')}
-            className='compact-input'
-          />
-        </FormItem>
-        <FormItem
-          label=''
+          label={e('localPort')}
           name={[field.name, 'sshTunnelLocalPort']}
+          initialValue={22}
           required
           className='mg2x'
         >
           <InputNumber
             min={1}
             max={65535}
-            addonBefore={e('localPort')}
+            // addonBefore={e('localPort')}
             className='compact-input'
+            placeholder={e('port')}
           />
         </FormItem>
         <Button

--- a/src/client/components/bookmark-form/render-ssh-tunnel.jsx
+++ b/src/client/components/bookmark-form/render-ssh-tunnel.jsx
@@ -52,7 +52,7 @@ export default function renderSshTunnel () {
           <FormItem
             label={e('destination')}
             name={[field.name, 'sshTunnelRemoteHost']}
-            initialValue={'127.0.0.1'}
+            initialValue='127.0.0.1'
             required
           >
             <Input


### PR DESCRIPTION
# Introduction
Add a putty-like SSH tunnel config on allowing to customize the remote host. Useful when accessing a jump-host.

# Example
![image](https://github.com/electerm/electerm/assets/49145984/7c51415b-4b2c-402f-b91a-7c64aef18a01)

