### PR TITLE
Fix web session format

### DIFF
--- a/src/client/components/bookmark-form/web-form-ui.jsx
+++ b/src/client/components/bookmark-form/web-form-ui.jsx
@@ -86,7 +86,7 @@ export default function LocalFormUi (props) {
                 !value || value.startsWith('http://') || value.startsWith('https://')
                   ? Promise.resolve()
                   : Promise.reject(new Error(e('URL must start with http:// or https://'))),
-            }
+            },
           ]}
         >
           <Input />

--- a/src/client/components/bookmark-form/web-form-ui.jsx
+++ b/src/client/components/bookmark-form/web-form-ui.jsx
@@ -85,8 +85,8 @@ export default function LocalFormUi (props) {
               validator: (_, value) =>
                 !value || value.startsWith('http://') || value.startsWith('https://')
                   ? Promise.resolve()
-                  : Promise.reject(new Error(e('URL must start with http:// or https://'))),
-            },
+                  : Promise.reject(new Error(e('URL must start with http:// or https://')))
+            }
           ]}
         >
           <Input />

--- a/src/client/components/bookmark-form/web-form-ui.jsx
+++ b/src/client/components/bookmark-form/web-form-ui.jsx
@@ -76,6 +76,18 @@ export default function LocalFormUi (props) {
           hasFeedback
           name='url'
           required
+          rules={[
+            {
+              required: true,
+              message: e('Please input URL')
+            },
+            {
+              validator: (_, value) =>
+                !value || value.startsWith('http://') || value.startsWith('https://')
+                  ? Promise.resolve()
+                  : Promise.reject(new Error(e('URL must start with http:// or https://'))),
+            }
+          ]}
         >
           <Input />
         </FormItem>


### PR DESCRIPTION
If url is none or not starts with http:// or https:// electerm will boom.

so,fix that like this:
<img width="1247" alt="image" src="https://github.com/user-attachments/assets/38ac5736-0adc-4a25-ac84-bef790b64e93">

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/69a0025c-7dc6-46d8-b191-2ac6757eed8b">
