### PR TITLE
fix: keyword highlighting only highlights first match per pattern

### DIFF
--- a/src/client/components/terminal/highlight-addon.js
+++ b/src/client/components/terminal/highlight-addon.js
@@ -79,17 +79,52 @@ export class KeywordHighlighterAddon {
       segments.push({ type: 'text', content: text.slice(lastIndex) })
     }
 
-    // Highlight only plain text segments
+    // Highlight only plain text segments using two-phase approach
+    // to prevent patterns from interfering with each other's ANSI codes
     const result = segments.map(seg => {
       if (seg.type === 'ansi') {
         return seg.content
       }
-      let content = seg.content
+      const content = seg.content
+      // Phase 1: collect all match positions from all patterns on original text
+      const matches = []
       for (const { regex, colorCode } of this.compiledPatterns) {
         regex.lastIndex = 0
-        content = content.replace(regex, (m) => `${colorCode}${m}\u001b[0m`)
+        let m
+        while ((m = regex.exec(content)) !== null) {
+          if (m[0].length === 0) {
+            regex.lastIndex++
+            continue
+          }
+          matches.push({
+            start: m.index,
+            end: m.index + m[0].length,
+            text: m[0],
+            colorCode
+          })
+        }
       }
-      return content
+      if (matches.length === 0) {
+        return content
+      }
+      // Phase 2: sort by position, remove overlaps (first pattern wins)
+      matches.sort((a, b) => a.start - b.start || a.end - b.end)
+      const filtered = [matches[0]]
+      for (let i = 1; i < matches.length; i++) {
+        if (matches[i].start >= filtered[filtered.length - 1].end) {
+          filtered.push(matches[i])
+        }
+      }
+      // Build result with ANSI codes inserted at correct positions
+      let highlighted = ''
+      let pos = 0
+      for (const m of filtered) {
+        highlighted += content.slice(pos, m.start)
+        highlighted += m.colorCode + m.text + '\u001b[0m'
+        pos = m.end
+      }
+      highlighted += content.slice(pos)
+      return highlighted
     }).join('')
 
     return result


### PR DESCRIPTION
Fixes #3907

## Problem

`highlightKeywords()` in `highlight-addon.js` applies keyword patterns sequentially via `content.replace()` in a loop. After pattern 1 inserts ANSI color codes (e.g. `\x1b[31m...\x1b[0m`), pattern 2 runs on the modified string and can:

- match inside ANSI escape sequences, corrupting output
- fail to match keywords adjacent to already-highlighted text

## Fix

Replace the sequential replace loop with a two-phase approach:

1. Collect all match positions from all patterns on the **original** plain text using `regex.exec()` in a while loop
2. Sort matches by position, remove overlaps (first-registered pattern wins), then build the result string in a single pass inserting ANSI codes at the correct offsets

This ensures patterns never interfere with each other.

## Test plan

1. Configure 2+ keywords (e.g. `error` in red, `warning` in yellow), run a command that outputs a line containing both — verify both are highlighted
2. Configure a single keyword, verify multiple occurrences on the same line are all highlighted (regression check)
3. Lint: `npx standard --verbose src/client/components/terminal/highlight-addon.js`