### PR TITLE
fix: suppress debug logging in production builds

### DIFF
--- a/src/app/common/log.js
+++ b/src/app/common/log.js
@@ -1,5 +1,11 @@
 const log = require('electron-log')
+const { isDev } = require('./runtime-constants')
 
 log.transports.console.format = '{h}:{i}:{s} {level} › {text}'
+
+if (!isDev) {
+  log.transports.console.level = 'warn'
+  log.transports.file.level = 'warn'
+}
 
 module.exports = exports.default = log


### PR DESCRIPTION
Fixes #3821

## Summary

`src/app/common/log.js` had no log level filtering — all debug/info messages were emitted regardless of environment. This imports `isDev` from `runtime-constants` and sets `console.level` and `file.level` to `'warn'` in production, suppressing the 46 `log.debug` calls across 8 files without touching any call sites.

## Test Plan

- `npx standard src/app/common/log.js` passes
- Run with `NODE_ENV=production` → debug/info messages suppressed
- Run with `NODE_ENV=development` → all log levels visible as before