### PR TITLE
Harden node-pty availability checks and runtime paths

### DIFF
--- a/build/bin/prepare.js
+++ b/build/bin/prepare.js
@@ -19,6 +19,7 @@ delete pack.standard
 delete pack.files
 delete pack.engines
 delete pack.preferGlobal
+delete pack.devDependencies
 
 if (isWin) {
   delete pack.dependencies['node-bash']
@@ -50,7 +51,7 @@ require('fs').writeFileSync(
   )
 )
 
-exec(`cd work/app && npm i --omit=dev && cd ${cwd}`)
+exec(`cd work/app && npm i --omit=dev --legacy-peer-deps && cd ${cwd}`)
 rm('-rf', 'work/app/node_modules/.bin')
 // Remove axios browser/ESM builds and unnecessary files (keep only lib/ and node CJS)
 rm('-rf', 'work/app/node_modules/axios/dist/esm')

--- a/src/app/common/runtime-constants.js
+++ b/src/app/common/runtime-constants.js
@@ -3,6 +3,7 @@
  */
 
 const os = require('os')
+const { existsSync } = require('fs')
 const { resolve } = require('path')
 
 const platform = os.platform()
@@ -14,25 +15,28 @@ const isArm = arch.includes('arm')
 
 const { NODE_ENV, NODE_TEST } = process.env
 const isDev = NODE_ENV === 'development'
-const iconPath = resolve(
-  __dirname,
-  (
-    isDev
-      ? '../../../node_modules/@electerm/electerm-resource/res/imgs/electerm-round-128x128.png'
-      : '../assets/images/electerm-round-128x128.png'
-  )
+const resolveFirstExisting = (...paths) => {
+  return paths.find(path => existsSync(path)) || paths[0]
+}
+const srcRoot = resolve(__dirname, '../../..')
+const appRoot = resolve(__dirname, '..')
+const iconPath = resolveFirstExisting(
+  resolve(srcRoot, 'node_modules/@electerm/electerm-resource/res/imgs/electerm-round-128x128.png'),
+  resolve(appRoot, 'assets/images/electerm-round-128x128.png')
 )
-const trayIconPath = resolve(
-  __dirname,
-  (
-    isDev
-      ? '../../../node_modules/@electerm/electerm-resource/tray-icons/electerm-tray.png'
-      : '../assets/images/electerm-tray.png'
-  )
+const trayIconPath = resolveFirstExisting(
+  resolve(srcRoot, 'node_modules/@electerm/electerm-resource/tray-icons/electerm-tray.png'),
+  resolve(appRoot, 'assets/images/electerm-tray.png')
 )
-const extIconPath = isDev
+const extIconPath = existsSync(
+  resolve(srcRoot, 'node_modules/electerm-icons/icons')
+)
   ? '/node_modules/electerm-icons/icons/'
   : 'icons/'
+const packInfoPath = resolveFirstExisting(
+  resolve(srcRoot, 'package.json'),
+  resolve(appRoot, 'package.json')
+)
 
 const defaultUserName = require('./default-user-name')
 
@@ -52,5 +56,5 @@ module.exports = {
   defaultLang: 'en_us',
   tempDir: require('os').tmpdir(),
   homeOrTmp: os.homedir() || os.tmpdir(),
-  packInfo: require(isDev ? '../../../package.json' : '../package.json')
+  packInfo: require(packInfoPath)
 }

--- a/src/app/lib/ipc-sync.js
+++ b/src/app/lib/ipc-sync.js
@@ -11,6 +11,9 @@ const contants = require('../common/runtime-constants')
 const windowMove = require('./window-drag-move.js')
 const globalState = require('./glob-state')
 const { transferKeys } = require('../server/transfer')
+const {
+  getNodePtyAvailability
+} = require('./node-pty-check')
 const os = require('os')
 const {
   isTest
@@ -37,12 +40,12 @@ const isMaximized = () => {
 
 module.exports = {
   nodePtyCheck: () => {
-    try {
-      return !!require('node-pty')
-    } catch (err) {
-      log.error('Failed to load node-pty:', err)
+    const result = getNodePtyAvailability()
+    if (!result.ok) {
+      log.error('Failed to load node-pty:', result.reason)
       return false
     }
+    return true
   },
   windowMove,
   getFsContants: () => {

--- a/src/app/lib/node-pty-check.js
+++ b/src/app/lib/node-pty-check.js
@@ -1,0 +1,75 @@
+const { existsSync } = require('fs')
+const { dirname, join } = require('path')
+const {
+  isWin
+} = require('../common/runtime-constants')
+
+function resolveNodePtyRoot () {
+  try {
+    const pkgPath = require.resolve('node-pty/package.json')
+    return dirname(pkgPath)
+  } catch (error) {
+    return ''
+  }
+}
+
+function getBindingsPaths (root) {
+  if (!root) {
+    return []
+  }
+  if (!isWin) {
+    return [
+      join(root, 'build/Release/pty.node'),
+      join(root, 'build/Debug/pty.node')
+    ]
+  }
+  return [
+    join(root, 'build/Release/conpty.node'),
+    join(root, 'build/Release/pty.node'),
+    join(root, 'build/Debug/conpty.node'),
+    join(root, 'build/Debug/pty.node')
+  ]
+}
+
+function getNodePtyAvailability () {
+  const root = resolveNodePtyRoot()
+  if (!root) {
+    return {
+      ok: false,
+      reason: 'node-pty package is not installed'
+    }
+  }
+  const bindingsPaths = getBindingsPaths(root)
+  const hasBindings = bindingsPaths.some(path => existsSync(path))
+  if (!hasBindings) {
+    return {
+      ok: false,
+      reason: `node-pty native binding is missing (${bindingsPaths.map(path => path.split(/[\\/]/).slice(-3).join('/')).join(', ')})`
+    }
+  }
+  try {
+    require('node-pty')
+    return {
+      ok: true,
+      reason: ''
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error.message
+    }
+  }
+}
+
+function assertNodePtyAvailable () {
+  const result = getNodePtyAvailability()
+  if (!result.ok) {
+    throw new Error(`Local terminal is unavailable because ${result.reason}`)
+  }
+  return require('node-pty')
+}
+
+module.exports = {
+  getNodePtyAvailability,
+  assertNodePtyAvailable
+}

--- a/src/app/server/session-local.js
+++ b/src/app/server/session-local.js
@@ -6,6 +6,9 @@ const { resolve: pathResolve } = require('path')
 const { TerminalBase } = require('./session-base')
 const globalState = require('./global-state')
 const { execSync } = require('child_process')
+const {
+  assertNodePtyAvailable
+} = require('../lib/node-pty-check')
 
 // const { MockBinding } = require('@serialport/binding-mock')
 // MockBinding.createPort('/dev/ROBOT', { echo: true, record: true })
@@ -53,7 +56,7 @@ class TerminalLocal extends TerminalBase {
       : platform === 'darwin' ? execMacArgs : execLinuxArgs
     const cwd = process.env[platform === 'win32' ? 'USERPROFILE' : 'HOME']
     const argv = platform.startsWith('darwin') ? ['--login', ...arg] : arg
-    const pty = require('node-pty')
+    const pty = assertNodePtyAvailable()
     const env = Object.assign({}, process.env)
     // if (!env.SystemRoot) {
     //   env.SystemRoot = process.env.windir


### PR DESCRIPTION
## Summary
- add an explicit node-pty availability check that verifies native bindings before local terminal startup
- return a clearer failure path from the main process instead of crashing when node-pty bindings are missing
- make runtime asset and package resolution more robust for source-run and development setups

## Notes
- this PR only covers node-pty/runtime fallback behavior
- it does not include title bar or unrelated UI changes

## Testing
- npm run compile