### PR TITLE
Improve Windows native title bar integration

### DIFF
--- a/src/app/lib/create-app.js
+++ b/src/app/lib/create-app.js
@@ -13,6 +13,9 @@ const {
 } = require('./deep-link')
 const { handleSingleInstance } = require('./single-instance')
 const log = require('../common/log')
+const {
+  invalidateRendererCacheIfNeeded
+} = require('./invalidate-renderer-cache')
 
 // GPU error suggestion message
 const GPU_ERROR_SUGGESTION = `
@@ -142,7 +145,10 @@ exports.createApp = async function () {
       win.focus()
     }
   })
-  app.whenReady().then(() => createWindow(conf))
+  app.whenReady().then(async () => {
+    await invalidateRendererCacheIfNeeded(app)
+    createWindow(conf)
+  })
   app.on('activate', () => {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.

--- a/src/app/lib/create-window.js
+++ b/src/app/lib/create-window.js
@@ -3,7 +3,7 @@ const {
 } = require('electron')
 const { resolve } = require('path')
 const {
-  isDev, packInfo, iconPath, isMac,
+  isDev, packInfo, iconPath, isMac, isWin,
   minWindowWidth, minWindowHeight
 } = require('../common/runtime-constants')
 const defaults = require('../common/default-setting')
@@ -25,7 +25,10 @@ exports.createWindow = async function (userConfig) {
   globalState.set('closeAction', 'closeApp')
   globalState.set('requireAuth', !!userConfig.hashedPassword)
   const { width, height, x, y } = await getWindowSize()
-  const { useSystemTitleBar = defaults.useSystemTitleBar } = userConfig
+  const useTitleBarOverlay = isWin
+  const useSystemTitleBar = !useTitleBarOverlay && (
+    userConfig.useSystemTitleBar === true || defaults.useSystemTitleBar
+  )
   const win = new BrowserWindow({
     width,
     height,
@@ -35,8 +38,16 @@ exports.createWindow = async function (userConfig) {
     minWidth: minWindowWidth,
     minHeight: minWindowHeight,
     title: packInfo.name,
-    frame: useSystemTitleBar,
-    transparent: !useSystemTitleBar,
+    autoHideMenuBar: isWin,
+    titleBarOverlay: useTitleBarOverlay
+      ? {
+          color: '#00000000',
+          symbolColor: '#ffffff',
+          height: 36
+        }
+      : false,
+    frame: useSystemTitleBar || useTitleBarOverlay,
+    transparent: !useSystemTitleBar && !useTitleBarOverlay,
     backgroundColor: '#333333',
     webPreferences: {
       contextIsolation: true,
@@ -53,6 +64,8 @@ exports.createWindow = async function (userConfig) {
   // hides the traffic lights
   if (isMac) {
     win.setWindowButtonVisibility(true)
+  } else if (isWin) {
+    win.setMenuBarVisibility(false)
   }
 
   win.webContents.session.setSpellCheckerDictionaryDownloadURL('https://00.00/')

--- a/src/app/lib/get-config.js
+++ b/src/app/lib/get-config.js
@@ -4,6 +4,9 @@ const getPort = require('./get-port')
 const { userConfigId } = require('../common/constants')
 const generate = require('../common/uid')
 const globalState = require('./glob-state')
+const {
+  isWin
+} = require('../common/runtime-constants')
 
 exports.getConfig = async (inited) => {
   const userConfig = await dbAction('data', 'findOne', {
@@ -26,6 +29,7 @@ exports.getConfig = async (inited) => {
     port,
     tokenElecterm: inited ? globalState.get('config').tokenElecterm : generate()
   }
+  config.useSystemTitleBar = !isWin && config.useSystemTitleBar === true
   return {
     userConfig,
     config

--- a/src/app/lib/invalidate-renderer-cache.js
+++ b/src/app/lib/invalidate-renderer-cache.js
@@ -1,0 +1,75 @@
+const { existsSync, readFileSync, writeFileSync, rmSync, statSync } = require('fs')
+const { join } = require('path')
+const log = require('../common/log')
+
+function getBuildFingerprint (app) {
+  try {
+    const appPath = app.getAppPath()
+    const stat = statSync(appPath)
+    return JSON.stringify({
+      version: app.getVersion(),
+      path: appPath,
+      mtimeMs: stat.mtimeMs,
+      size: stat.size || 0
+    })
+  } catch (error) {
+    log.warn('failed to build cache fingerprint', error)
+    return ''
+  }
+}
+
+function safeRemoveDir (path) {
+  try {
+    if (existsSync(path)) {
+      rmSync(path, {
+        recursive: true,
+        force: true
+      })
+    }
+  } catch (error) {
+    log.warn(`failed to remove cache dir: ${path}`, error)
+  }
+}
+
+async function invalidateRendererCacheIfNeeded (app) {
+  if (!app.isPackaged) {
+    return
+  }
+  const fingerprint = getBuildFingerprint(app)
+  if (!fingerprint) {
+    return
+  }
+  const userData = app.getPath('userData')
+  const marker = join(userData, 'renderer-build-fingerprint.json')
+  let prevFingerprint = ''
+  try {
+    if (existsSync(marker)) {
+      prevFingerprint = readFileSync(marker, 'utf8')
+    }
+  } catch (error) {
+    log.warn('failed to read renderer fingerprint marker', error)
+  }
+  if (prevFingerprint === fingerprint) {
+    return
+  }
+
+  ;[
+    'Cache',
+    'Code Cache',
+    'GPUCache',
+    'DawnGraphiteCache',
+    'DawnWebGPUCache'
+  ].forEach(dir => {
+    safeRemoveDir(join(userData, dir))
+  })
+
+  try {
+    writeFileSync(marker, fingerprint)
+  } catch (error) {
+    log.warn('failed to write renderer fingerprint marker', error)
+  }
+}
+
+module.exports = {
+  invalidateRendererCacheIfNeeded
+}

--- a/src/client/common/should-use-native-window-controls.js
+++ b/src/client/common/should-use-native-window-controls.js
@@ -1,0 +1,9 @@
+import {
+  isMacJs
+} from './constants'
+import shouldUseSystemTitleBar from './should-use-system-title-bar'
+import shouldUseTitleBarOverlay from './should-use-title-bar-overlay'
+
+export default function shouldUseNativeWindowControls (config = {}) {
+  return isMacJs || shouldUseSystemTitleBar(config) || shouldUseTitleBarOverlay()
+}

--- a/src/client/common/should-use-system-title-bar.js
+++ b/src/client/common/should-use-system-title-bar.js
@@ -1,0 +1,3 @@
+export default function shouldUseSystemTitleBar (config = {}) {
+  return config.useSystemTitleBar === true
+}

--- a/src/client/common/should-use-title-bar-overlay.js
+++ b/src/client/common/should-use-title-bar-overlay.js
@@ -1,0 +1,7 @@
+import {
+  isWin
+} from './constants'
+
+export default function shouldUseTitleBarOverlay () {
+  return isWin && !window.et.isWebApp
+}

--- a/src/client/components/main/main.jsx
+++ b/src/client/components/main/main.jsx
@@ -36,6 +36,8 @@ import WorkspaceSaveModal from '../tabs/workspace-save-modal'
 import BookmarkFromHistoryModal from '../bookmark-form/bookmark-from-history-modal'
 import { pick } from 'lodash-es'
 import deepCopy from 'json-deep-copy'
+import shouldUseSystemTitleBar from '../../common/should-use-system-title-bar'
+import shouldUseTitleBarOverlay from '../../common/should-use-title-bar-overlay'
 import './wrapper.styl'
 import './term-fullscreen.styl'
 
@@ -95,12 +97,15 @@ export default auto(function Index (props) {
     rightPanelTitle,
     rightPanelTab
   } = store
+  const useSystemTitleBar = shouldUseSystemTitleBar(config)
+  const useTitleBarOverlay = shouldUseTitleBarOverlay()
   const upgradeInfo = deepCopy(store.upgradeInfo)
   const cls = classnames({
     loaded: configLoaded,
     'not-webapp': !window.et.isWebApp,
-    'system-ui': store.config.useSystemTitleBar,
-    'not-system-ui': !store.config.useSystemTitleBar,
+    'system-ui': useSystemTitleBar,
+    'not-system-ui': !useSystemTitleBar,
+    'titlebar-overlay': useTitleBarOverlay,
     'is-mac': isMac,
     'not-mac': !isMac,
     'is-win': isWin,

--- a/src/client/components/setting-panel/setting-common.jsx
+++ b/src/client/components/setting-panel/setting-common.jsx
@@ -22,7 +22,8 @@ import InputNumberConfirm from '../common/input-number-confirm'
 import TextareaConfirm from '../common/textarea-confirm'
 import {
   settingMap,
-  proxyHelpLink
+  proxyHelpLink,
+  isWin
 } from '../../common/constants'
 import defaultSettings from '../../common/default-setting'
 import Link from '../common/external-link'
@@ -468,6 +469,21 @@ export default class SettingCommon extends Component {
       hotkey,
       onSaveConfig: this.saveConfig
     }
+    const toggleNames = [
+      'autoRefreshWhenSwitchToSftp',
+      'showHiddenFilesOnSftpStart',
+      'screenReaderMode',
+      'initDefaultTabOnStart',
+      'disableConnectionHistory',
+      'disableTransferHistory',
+      'checkUpdateOnStart',
+      'useSystemTitleBar',
+      'confirmBeforeExit',
+      'hideIP',
+      'allowMultiInstance',
+      'disableDeveloperTool',
+      'debug'
+    ].filter(name => !isWin || name !== 'useSystemTitleBar')
     return (
       <div className='form-wrap pd1y pd2x'>
         <h2>{e('settings')}</h2>
@@ -589,21 +605,7 @@ export default class SettingCommon extends Component {
           this.renderText('keyword2FA')
         }
         {
-          [
-            'autoRefreshWhenSwitchToSftp',
-            'showHiddenFilesOnSftpStart',
-            'screenReaderMode',
-            'initDefaultTabOnStart',
-            'disableConnectionHistory',
-            'disableTransferHistory',
-            'checkUpdateOnStart',
-            'useSystemTitleBar',
-            'confirmBeforeExit',
-            'hideIP',
-            'allowMultiInstance',
-            'disableDeveloperTool',
-            'debug'
-          ].map(this.renderToggle)
+          toggleNames.map(this.renderToggle)
         }
         {
           window.et.isWebApp ? null : <DeepLinkControl />

--- a/src/client/components/tabs/app-drag.jsx
+++ b/src/client/components/tabs/app-drag.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react'
+import shouldUseSystemTitleBar from '../../common/should-use-system-title-bar'
 
 export default function AppDrag (props) {
   const isDraggingRef = useRef(false)
+  const useSystemTitleBar = shouldUseSystemTitleBar(window.store?.config)
 
   function canOperate (e) {
     const {
@@ -20,6 +22,9 @@ export default function AppDrag (props) {
   }
 
   useEffect(() => {
+    if (useSystemTitleBar) {
+      return
+    }
     if (window.store.shouldSendWindowMove) {
       return
     }
@@ -30,7 +35,11 @@ export default function AppDrag (props) {
       document.removeEventListener('mouseup', onMouseUp)
       window.removeEventListener('contextmenu', onMouseUp)
     }
-  }, [])
+  }, [useSystemTitleBar])
+
+  if (useSystemTitleBar) {
+    return props.children || null
+  }
 
   function onMouseDown (e) {
     // e.stopPropagation()

--- a/src/client/components/tabs/index.jsx
+++ b/src/client/components/tabs/index.jsx
@@ -28,6 +28,8 @@ import AddBtn from './add-btn'
 import AppDrag from './app-drag'
 import NoSession from './no-session'
 import classNames from 'classnames'
+import shouldUseSystemTitleBar from '../../common/should-use-system-title-bar'
+import shouldUseTitleBarOverlay from '../../common/should-use-title-bar-overlay'
 
 export default class Tabs extends Component {
   constructor (props) {
@@ -238,7 +240,7 @@ export default class Tabs extends Component {
 
   renderContent () {
     const { config } = this.props
-    if (config.useSystemTitleBar) {
+    if (shouldUseSystemTitleBar(config)) {
       return this.renderContentInner()
     }
     return (
@@ -253,12 +255,14 @@ export default class Tabs extends Component {
     const len = tabs.length
     const tabsWidthAll = tabMargin * len + 10 + this.tabsWidth()
     const { overflow } = this.state
+    const useSystemTitleBar = shouldUseSystemTitleBar(config)
+    const useTitleBarOverlay = shouldUseTitleBarOverlay()
     const left = overflow
       ? '100%'
       : tabsWidthAll
-    const w1 = isMacJs && (config.useSystemTitleBar || window.et.isWebApp)
+    const w1 = isMacJs && (useSystemTitleBar || window.et.isWebApp)
       ? 30
-      : this.getExtraTabWidth()
+      : this.getExtraTabWidth(useTitleBarOverlay)
     const style = {
       width: width - w1 - 166
     }
@@ -332,7 +336,12 @@ export default class Tabs extends Component {
     return batch === batchToRender[layout]
   }
 
-  getExtraTabWidth = () => {
+  getExtraTabWidth = (useTitleBarOverlay = shouldUseTitleBarOverlay()) => {
+    if (useTitleBarOverlay) {
+      return this.shouldRenderWindowControl()
+        ? 140
+        : 0
+    }
     return this.shouldRenderWindowControl()
       ? windowControlWidth
       : 0

--- a/src/client/components/tabs/layout-menu.jsx
+++ b/src/client/components/tabs/layout-menu.jsx
@@ -9,8 +9,7 @@ import {
   AppstoreOutlined,
   LayoutOutlined
 } from '@ant-design/icons'
-import { splitMapDesc } from '../../common/constants'
-import LayoutSelect, { getLayoutIcon } from './layout-select'
+import LayoutSelect from './layout-select'
 import WorkspaceSelect from './workspace-select'
 import HelpIcon from '../common/help-icon'
 
@@ -44,9 +43,6 @@ export default function LayoutMenu (props) {
     }
   ]
 
-  const v = splitMapDesc[layout]
-  const Icon = getLayoutIcon(v)
-
   const dropdownContent = (
     <div className='layout-workspace-dropdown'>
       <Tabs
@@ -67,8 +63,12 @@ export default function LayoutMenu (props) {
       placement='bottomRight'
       trigger={['click']}
     >
-      <span className='tabs-dd-icon layout-dd-icon mg1l'>
-        <Icon /> <DownOutlined />
+      <span
+        className='tabs-dd-icon layout-dd-icon'
+        title={e('layout')}
+      >
+        <LayoutOutlined className='layout-trigger-icon' />
+        <DownOutlined className='layout-trigger-arrow' />
       </span>
     </Dropdown>
   )

--- a/src/client/components/tabs/tabs.styl
+++ b/src/client/components/tabs/tabs.styl
@@ -19,6 +19,9 @@
 .not-system-ui.not-mac.not-webapp
   .tabs-extra
     right 96px
+.titlebar-overlay.is-win.not-webapp
+  .tabs-extra
+    right 140px
 .tabs-inner
   position relative
   z-index 2
@@ -149,16 +152,40 @@
     color var(--text-light)
 .tabs-extra
   position absolute
-  height 40px
+  display flex
+  align-items center
+  gap 6px
+  height 36px
   top 0
   right 0
-  line-height 40px
+  line-height 1
   z-index 20
 
   .tabs-dd-icon
     font-size 12px
   .tabs-add-btn
     margin-top 0
+
+.layout-dd-icon
+  display inline-flex
+  align-items center
+  justify-content center
+  height 28px
+  min-width 32px
+  padding 0 6px
+  gap 4px
+  border-radius 6px
+  color var(--text-dark)
+  vertical-align middle
+  &:hover
+    color var(--text)
+    background var(--main-lighter)
+
+.layout-trigger-icon
+  font-size 13px
+
+.layout-trigger-arrow
+  font-size 10px
 
 .window-controls
   position absolute
@@ -294,6 +321,7 @@
   white-space nowrap
 
 .not-webapp.not-win
+.titlebar-overlay.is-win.not-webapp
   .tab
   .tabs-add-btn
   .window-control-box

--- a/src/client/components/tabs/window-control.jsx
+++ b/src/client/components/tabs/window-control.jsx
@@ -7,6 +7,7 @@ import { auto } from 'manate/react'
 import {
   isMacJs
 } from '../../common/constants'
+import shouldUseNativeWindowControls from '../../common/should-use-native-window-controls'
 
 const e = window.translate
 
@@ -15,7 +16,7 @@ export default auto(function WindowControl (props) {
     isMaximized,
     config
   } = props.store
-  if (config.useSystemTitleBar || isMacJs) {
+  if (shouldUseNativeWindowControls(config) || isMacJs) {
     return null
   }
   const minimize = () => {

--- a/src/client/store/store.js
+++ b/src/client/store/store.js
@@ -41,6 +41,8 @@ import {
 } from '../common/constants'
 import getInitItem from '../common/init-setting-item'
 import createTitle from '../common/create-title'
+import shouldUseSystemTitleBar from '../common/should-use-system-title-bar'
+import shouldUseTitleBarOverlay from '../common/should-use-title-bar-overlay'
 import {
   theme
 } from 'antd'
@@ -93,7 +95,8 @@ class Store {
   get shouldSendWindowMove () {
     return isWin &&
         !window.et.isWebApp &&
-        !window.store.config.useSystemTitleBar
+        !shouldUseSystemTitleBar(window.store.config) &&
+        !shouldUseTitleBarOverlay()
   }
 
   get batchInputSelectedTabIds () {


### PR DESCRIPTION
## Summary
- improve Windows native title bar handling and title bar overlay integration
- hide the unsupported system title bar toggle on Windows and centralize title bar capability checks
- invalidate stale renderer cache after packaged app updates so title bar changes apply reliably

## Notes
- this PR only covers Windows title bar and window control behavior
- it does not include node-pty fallback or icon migration work

## Testing
- npm run compile