### PR TITLE
Migrate AI panel icons to lucide-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "iconv-lite": "^0.7.2",
         "json-deep-copy": "1.3.1",
         "jsonwebtoken": "^9.0.1",
+        "lucide-react": "^1.0.1",
         "nanoid": "3.3.8",
         "node-bash": "5.0.1",
         "node-forge": "1.3.3",
@@ -10101,6 +10102,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-1.0.1.tgz",
+      "integrity": "sha512-lih7tKEczCYOQjVEzpFuxEuNzlwf+1yhvlMlEkGWJM3va8Pugv8bYXc/pRtcjPncaP7k84X0Pt/71ufxvqEPtQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/make-fetch-happen": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "iconv-lite": "^0.7.2",
     "json-deep-copy": "1.3.1",
     "jsonwebtoken": "^9.0.1",
+    "lucide-react": "^1.0.1",
     "nanoid": "3.3.8",
     "node-bash": "5.0.1",
     "node-forge": "1.3.3",

--- a/src/client/components/ai/ai-chat-history-item.jsx
+++ b/src/client/components/ai/ai-chat-history-item.jsx
@@ -4,13 +4,7 @@ import {
   Alert,
   Tooltip
 } from 'antd'
-import {
-  UserOutlined,
-  CopyOutlined,
-  CloseOutlined,
-  CaretDownOutlined,
-  CaretRightOutlined
-} from '@ant-design/icons'
+import { User, Copy, X, ChevronDown, ChevronRight } from 'lucide-react'
 import { copy } from '../../common/clipboard'
 import { useState } from 'react'
 
@@ -28,9 +22,9 @@ export default function AIChatHistoryItem ({ item }) {
     title: (
       <>
         <span className='pointer mg1r' onClick={toggleOutput}>
-          {showOutput ? <CaretDownOutlined /> : <CaretRightOutlined />}
+          {showOutput ? <ChevronDown /> : <ChevronRight />}
         </span>
-        <UserOutlined />: {prompt}
+        <User />: {prompt}
       </>
     ),
     type: 'info'
@@ -58,11 +52,11 @@ export default function AIChatHistoryItem ({ item }) {
           <b>Time:</b> {new Date(item.timestamp).toLocaleString()}
         </p>
         <p>
-          <CopyOutlined
+          <Copy
             className='pointer'
             onClick={handleCopy}
           />
-          <CloseOutlined
+          <X
             className='pointer mg1l'
             onClick={handleDel}
           />

--- a/src/client/components/ai/ai-chat.jsx
+++ b/src/client/components/ai/ai-chat.jsx
@@ -4,11 +4,7 @@ import TabSelect from '../footer/tab-select'
 import AiChatHistory from './ai-chat-history'
 import uid from '../../common/uid'
 import { pick } from 'lodash-es'
-import {
-  SettingOutlined,
-  SendOutlined,
-  UnorderedListOutlined
-} from '@ant-design/icons'
+import { Settings, Send, List } from 'lucide-react'
 import {
   aiConfigWikiLink
 } from '../../common/constants'
@@ -224,7 +220,7 @@ export default function AIChat (props) {
       )
     }
     return (
-      <SendOutlined
+      <Send
         onClick={handleSubmit}
         className='mg1l pointer icon-hover send-to-ai-icon'
         title='Enter to send, Shift+Enter for new line'
@@ -280,11 +276,11 @@ export default function AIChat (props) {
               tabs={props.tabs}
               activeTabId={props.activeTabId}
             />
-            <SettingOutlined
+            <Settings
               onClick={toggleConfig}
               className='mg1l pointer icon-hover toggle-ai-setting-icon'
             />
-            <UnorderedListOutlined
+            <List
               onClick={clearHistory}
               className='mg2x pointer clear-ai-icon icon-hover'
               title='Clear AI chat history'

--- a/src/client/components/ai/ai-history.jsx
+++ b/src/client/components/ai/ai-history.jsx
@@ -3,7 +3,7 @@
  */
 import { useState, useEffect } from 'react'
 import { Space } from 'antd'
-import { HistoryOutlined } from '@ant-design/icons'
+import { History } from 'lucide-react'
 import { getItemJSON, setItemJSON } from '../../common/safe-local-storage'
 import AiHistoryItem from './ai-history-item'
 
@@ -82,7 +82,7 @@ export default function AiHistory (props) {
   return (
     <div className='ai-bookmark-history pd1b'>
       <div className='pd1b text-muted'>
-        <HistoryOutlined className='mg1r' />
+        <History className='mg1r' />
         <span className='mg1r'>{e('history') || 'History'}:</span>
       </div>
       <Space size={[8, 8]} wrap>

--- a/src/client/components/ai/ai-output.jsx
+++ b/src/client/components/ai/ai-output.jsx
@@ -2,7 +2,7 @@ import ReactMarkdown from 'react-markdown'
 import { copy } from '../../common/clipboard'
 import Link from '../common/external-link'
 import { Tag } from 'antd'
-import { CopyOutlined, PlayCircleOutlined } from '@ant-design/icons'
+import { Copy, PlayCircle } from 'lucide-react'
 import getBrand from './get-brand'
 
 const e = window.translate
@@ -59,12 +59,12 @@ export default function AIOutput ({ item }) {
     return (
       <div className='code-block'>
         <div className='code-block-actions alignright'>
-          <CopyOutlined
+          <Copy
             className='code-action-icon pointer iblock'
             onClick={copyToClipboard}
             title={e('copy')}
           />
-          <PlayCircleOutlined
+          <PlayCircle
             className='code-action-icon pointer mg1l iblock'
             onClick={runInTerminal}
           />

--- a/src/client/components/ai/ai-stop-icon.jsx
+++ b/src/client/components/ai/ai-stop-icon.jsx
@@ -1,4 +1,4 @@
-import { LoadingOutlined } from '@ant-design/icons'
+import { Loader2 } from 'lucide-react'
 
 export default function AIStopIcon (props) {
   return (
@@ -7,7 +7,7 @@ export default function AIStopIcon (props) {
       onClick={props.onClick}
       title={props.title || 'Stop AI request'}
     >
-      <LoadingOutlined spin />
+      <Loader2 spin />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace AI panel icons with lucide-react equivalents
- keep the AI UI behavior unchanged while removing direct @ant-design/icons usage in this area

## Notes
- scoped to AI-related components only
- shares the lucide-react dependency introduced in #4241

## Testing
- npm run compile