### PR TITLE
Migrate sidebar and footer icons to lucide-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "iconv-lite": "^0.7.2",
         "json-deep-copy": "1.3.1",
         "jsonwebtoken": "^9.0.1",
+        "lucide-react": "^1.0.1",
         "nanoid": "3.3.8",
         "node-bash": "5.0.1",
         "node-forge": "1.3.3",
@@ -10101,6 +10102,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-1.0.1.tgz",
+      "integrity": "sha512-lih7tKEczCYOQjVEzpFuxEuNzlwf+1yhvlMlEkGWJM3va8Pugv8bYXc/pRtcjPncaP7k84X0Pt/71ufxvqEPtQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/make-fetch-happen": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "iconv-lite": "^0.7.2",
     "json-deep-copy": "1.3.1",
     "jsonwebtoken": "^9.0.1",
+    "lucide-react": "^1.0.1",
     "nanoid": "3.3.8",
     "node-bash": "5.0.1",
     "node-forge": "1.3.3",

--- a/src/client/components/footer/cmd-history.jsx
+++ b/src/client/components/footer/cmd-history.jsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from 'react'
 import { Button, Empty, Popover, Switch } from 'antd'
 import { auto } from 'manate/react'
 import { copy } from '../../common/clipboard'
-import { HistoryOutlined, DeleteOutlined, CopyOutlined, UnorderedListOutlined } from '@ant-design/icons'
+import { History, Trash2, Copy, List } from 'lucide-react'
 import InputAutoFocus from '../common/input-auto-focus'
 import { getItemJSON, setItemJSON } from '../../common/safe-local-storage'
 import './cmd-history.styl'
@@ -91,14 +91,14 @@ export default auto(function CmdHistory (props) {
           <Button
             type='text'
             size='small'
-            icon={<CopyOutlined />}
+            icon={<Copy />}
             className='cmd-history-item-copy'
             onClick={(ev) => handleCopyCommand(item.cmd, ev)}
           />
           <Button
             type='text'
             size='small'
-            icon={<DeleteOutlined />}
+            icon={<Trash2 />}
             className='cmd-history-item-delete'
             onClick={(ev) => handleDeleteCommand(item.cmd, ev)}
           />
@@ -126,7 +126,7 @@ export default auto(function CmdHistory (props) {
           onChange={handleSortByFrequencyChange}
           size='small'
         />
-        <UnorderedListOutlined
+        <List
           className='cmd-history-clear-icon pointer clear-ai-icon icon-hover'
           title={e('clear')}
           onClick={handleClearAll}
@@ -147,7 +147,7 @@ export default auto(function CmdHistory (props) {
       <Button
         size='small'
         type='text'
-        icon={<HistoryOutlined />}
+        icon={<History />}
       />
     </Popover>
   )

--- a/src/client/components/footer/footer-entry.jsx
+++ b/src/client/components/footer/footer-entry.jsx
@@ -2,7 +2,7 @@ import { auto } from 'manate/react'
 import {
   Select
 } from 'antd'
-import { InfoCircleOutlined } from '@ant-design/icons'
+import { Info } from 'lucide-react'
 import './footer.styl'
 import { statusMap } from '../../common/constants'
 import BatchInput from './batch-input'
@@ -124,7 +124,7 @@ export default auto(function FooterEntry (props) {
     }
     return (
       <div className='terminal-footer-unit terminal-footer-info'>
-        <InfoCircleOutlined
+        <Info
           onClick={handleInfoPanel}
           className='pointer font18 terminal-info-icon'
         />

--- a/src/client/components/footer/tab-select.jsx
+++ b/src/client/components/footer/tab-select.jsx
@@ -2,9 +2,7 @@ import {
   Popover
 } from 'antd'
 import TabItem from './batch-item'
-import {
-  CodeOutlined
-} from '@ant-design/icons'
+import { Code } from 'lucide-react'
 
 export default function TabSelect (props) {
   const { selectedTabIds, tabs, activeTabId } = props
@@ -64,7 +62,7 @@ export default function TabSelect (props) {
       trigger='click'
     >
       <span className='pointer iblock pd1x'>
-        ({selectedTabIds.length}) <CodeOutlined />
+        ({selectedTabIds.length}) <Code />
       </span>
     </Popover>
   )

--- a/src/client/components/sidebar/index.jsx
+++ b/src/client/components/sidebar/index.jsx
@@ -1,15 +1,4 @@
-import {
-  BookOutlined,
-  CloudSyncOutlined,
-  InfoCircleOutlined,
-  PictureOutlined,
-  PlusCircleOutlined,
-  SettingOutlined,
-  UpCircleOutlined,
-  BarsOutlined,
-  AppstoreOutlined,
-  ThunderboltOutlined
-} from '@ant-design/icons'
+import { Book, RefreshCw, Info, Image, PlusCircle, Settings, ArrowUpCircle, Menu, LayoutGrid, Zap } from 'lucide-react'
 import { Tooltip, Popover } from 'antd'
 import SideBarPanel from './sidebar-panel'
 import TransferList from './transfer-list'
@@ -139,8 +128,8 @@ export default function Sidebar (props) {
         <SideIcon
           title={e('newBookmark')}
         >
-          <PlusCircleOutlined
-            className='font22 iblock control-icon'
+          <PlusCircle
+            className='iblock control-icon'
             onClick={onNewSsh}
           />
         </SideIcon>
@@ -150,8 +139,8 @@ export default function Sidebar (props) {
           placement='right'
         >
           <div className='control-icon-wrap' title={e('quickConnect')}>
-            <ThunderboltOutlined
-              className='font20 iblock control-icon'
+            <Zap
+              className='iblock control-icon'
             />
           </div>
         </Popover>
@@ -159,9 +148,9 @@ export default function Sidebar (props) {
           title={e(settingMap.bookmarks)}
           active={bookmarksActive}
         >
-          <BookOutlined
+          <Book
             onClick={handleClickBookmark}
-            className='font20 iblock control-icon'
+            className='iblock control-icon'
           />
         </SideIcon>
         <TransferList {...transferProps} />
@@ -169,8 +158,8 @@ export default function Sidebar (props) {
           title={e(settingMap.terminalThemes)}
           active={themeActive}
         >
-          <PictureOutlined
-            className='font20 iblock pointer control-icon'
+          <Image
+            className='iblock pointer control-icon'
             onClick={openTerminalThemes}
           />
         </SideIcon>
@@ -178,37 +167,36 @@ export default function Sidebar (props) {
           title={e(settingMap.setting)}
           active={settingActive}
         >
-          <SettingOutlined className='iblock font20 control-icon' onClick={openSetting} />
+          <Settings className='iblock control-icon' onClick={openSetting} />
         </SideIcon>
         <SideIcon
           title={e('settingSync')}
           active={syncActive}
         >
-          <CloudSyncOutlined
-            className='iblock font20 control-icon'
+          <RefreshCw
+            className={`iblock control-icon ${isSyncingSetting ? 'anticon-spin' : ''}`}
             onClick={openSettingSync}
-            spin={isSyncingSetting}
           />
         </SideIcon>
         <SideIcon
           title={e('batchOp')}
           active={showBatchOp}
         >
-          <BarsOutlined className='iblock font20 control-icon' onClick={toggleBatchOp} />
+          <Menu className='iblock control-icon' onClick={toggleBatchOp} />
         </SideIcon>
         <SideIcon
           title={e('widgets')}
           active={widgetsActive}
         >
-          <AppstoreOutlined className='iblock font20 control-icon' onClick={openWidgetsModal} />
+          <LayoutGrid className='iblock control-icon' onClick={openWidgetsModal} />
         </SideIcon>
 
         <SideIcon
           title={e('about')}
           active={showInfoModal}
         >
-          <InfoCircleOutlined
-            className='iblock font16 control-icon open-about-icon'
+          <Info
+            className='iblock control-icon open-about-icon'
             onClick={openAbout}
           />
         </SideIcon>
@@ -222,8 +210,8 @@ export default function Sidebar (props) {
                 <div
                   className='control-icon-wrap'
                 >
-                  <UpCircleOutlined
-                    className='iblock font18 control-icon upgrade-icon'
+                  <ArrowUpCircle
+                    className='iblock control-icon upgrade-icon'
                     onClick={handleShowUpgrade}
                   />
                 </div>

--- a/src/client/components/sidebar/info-modal.jsx
+++ b/src/client/components/sidebar/info-modal.jsx
@@ -1,15 +1,5 @@
-import {
-  GithubOutlined,
-  GlobalOutlined,
-  HighlightOutlined,
-  HomeOutlined,
-  UserOutlined,
-  WarningOutlined,
-  InfoCircleOutlined,
-  AlignLeftOutlined,
-  BugOutlined,
-  HeartOutlined
-} from '@ant-design/icons'
+import { Globe, Highlighter, Home, User, AlertTriangle, Info, AlignLeft, Bug, Heart } from 'lucide-react'
+import { GithubOutlined as Github } from '@ant-design/icons'
 import { Tabs, Button } from 'antd'
 import Modal from '../common/modal'
 import Link from '../common/external-link'
@@ -141,7 +131,7 @@ export default auto(function InfoModal (props) {
   }
   const title = (
     <div className='custom-modal-close-confirm-title font16'>
-      <InfoCircleOutlined className='font20 mg1r' /> {e('about')} {name}
+      <Info className='font20 mg1r' /> {e('about')} {name}
     </div>
   )
   const attrs = {
@@ -162,61 +152,61 @@ export default auto(function InfoModal (props) {
           <p className='mg2b'>{e('desc')}</p>
           <RunningTime />
           <p className='mg1b'>
-            <HomeOutlined /> <b>{e('homepage')}/{e('download')} ➾</b>
+            <Home /> <b>{e('homepage')}/{e('download')} ➾</b>
             <Link to={homepage} className='mg1l'>
               {homepage}
             </Link>
           </p>
           <p className='mg1b'>
-            <UserOutlined /> <b className='mg1r'>{e('author')} ➾</b>
+            <User /> <b className='mg1r'>{e('author')} ➾</b>
             <Link to={authorUrl} className='mg1l'>
               {authorName} ({email})
             </Link>
           </p>
           <p className='mg1b'>
-            <GithubOutlined /> <b className='mg1r'>github ➾</b>
+            <Github /> <b className='mg1r'>github ➾</b>
             <Link to={link} className='mg1l'>
               {link}
             </Link>
           </p>
           <p className='mg1b'>
-            <GlobalOutlined /> <b className='mg1r'>{e('language')} repo ➾</b>
+            <Globe /> <b className='mg1r'>{e('language')} repo ➾</b>
             <Link to={langugeRepo} className='mg1l'>
               {langugeRepo}
             </Link>
           </p>
           <p className='mg1b'>
-            <BugOutlined /> <b className='mg1r'>{e('bugReport')} ➾</b>
+            <Bug /> <b className='mg1r'>{e('bugReport')} ➾</b>
             <Link to={bugReportLink} className='mg1l'>
               {bugReportLink}
             </Link>
           </p>
           <p className='mg1b'>
-            <HighlightOutlined /> <b className='mg1r'>{e('changeLog')} ➾</b>
+            <Highlighter /> <b className='mg1r'>{e('changeLog')} ➾</b>
             <Link to={releaseLink} className='mg1l'>
               {releaseLink}
             </Link>
           </p>
           <p className='mg1b'>
-            <AlignLeftOutlined /> <b className='mg1r'>{e('knownIssues')} ➾</b>
+            <AlignLeft /> <b className='mg1r'>{e('knownIssues')} ➾</b>
             <Link to={knownIssuesLink} className='mg1l'>
               {knownIssuesLink}
             </Link>
           </p>
           <p className='mg1b'>
-            <WarningOutlined /> <b className='mg1r'>{e('privacyNotice')} ➾</b>
+            <AlertTriangle /> <b className='mg1r'>{e('privacyNotice')} ➾</b>
             <Link to={privacyNoticeLink} className='mg1l'>
               {privacyNoticeLink}
             </Link>
           </p>
           <p className='mg1b'>
-            <HeartOutlined /> <b className='mg1r'>{e('sponsorElecterm')} ➾</b>
+            <Heart /> <b className='mg1r'>{e('sponsorElecterm')} ➾</b>
             <Link to={sponsorLink} className='mg1l'>
               {sponsorLink}
             </Link>
           </p>
           <p className='mg1b'>
-            <InfoCircleOutlined /> <b className='mg1r'>{window.store.installSrc}</b>
+            <Info /> <b className='mg1r'>{window.store.installSrc}</b>
           </p>
           {renderCheckUpdate()}
         </>

--- a/src/client/components/sidebar/sidebar-panel.jsx
+++ b/src/client/components/sidebar/sidebar-panel.jsx
@@ -7,14 +7,7 @@ import BookmarkWrap from './bookmark'
 import History from './history'
 import { Tabs, Tooltip } from 'antd'
 import MultiSelectModal from '../common/multi-select-modal'
-import {
-  ArrowsAltOutlined,
-  EditOutlined,
-  PlusCircleOutlined,
-  ShrinkOutlined,
-  PushpinOutlined,
-  SelectOutlined
-} from '@ant-design/icons'
+import { Maximize2, Edit, PlusCircle, Shrink, Pin, Pointer } from 'lucide-react'
 
 const e = window.translate
 
@@ -63,17 +56,17 @@ export default memo(function SidebarPanel (props) {
     }
     return [
       <Tooltip title={e('expandAll')} key='expand'>
-        <ArrowsAltOutlined
+        <Maximize2
           {...pop2}
         />
       </Tooltip>,
       <Tooltip title={e('collapseAll')} key='collapse'>
-        <ShrinkOutlined
+        <Shrink
           {...pop3}
         />
       </Tooltip>,
       <Tooltip title={e('open') + ' ' + e('bookmarks')} key='multi'>
-        <SelectOutlined
+        <Pointer
           {...prps}
           onClick={() => setOpenSelectModal(true)}
         />
@@ -87,12 +80,12 @@ export default memo(function SidebarPanel (props) {
       <div className='sidebar-pin-top'>
         <div className='pd1y pd2t pd2x sidebar-panel-control alignright'>
           <Tooltip title={e('newBookmark')}>
-            <PlusCircleOutlined
+            <PlusCircle
               {...pop1}
             />
           </Tooltip>
           <Tooltip title={`${e('edit')} ${e('bookmarks')}`}>
-            <EditOutlined
+            <Edit
               {...pop1}
             />
           </Tooltip>
@@ -100,7 +93,7 @@ export default memo(function SidebarPanel (props) {
             renderExpandIcons()
           }
           <Tooltip title={e('pin')}>
-            <PushpinOutlined
+            <Pin
               {...prps1}
               onClick={store.handlePin}
             />

--- a/src/client/components/sidebar/transfer-list.jsx
+++ b/src/client/components/sidebar/transfer-list.jsx
@@ -1,7 +1,5 @@
 import { memo } from 'react'
-import {
-  SwapOutlined
-} from '@ant-design/icons'
+import { ArrowLeftRight } from 'lucide-react'
 import {
   Badge,
   Popover
@@ -51,7 +49,7 @@ export default memo(function TransferList (props) {
         <Badge
           {...bdProps}
         >
-          <SwapOutlined
+          <ArrowLeftRight
             className='iblock font20 control-icon'
           />
         </Badge>

--- a/src/client/components/sidebar/transport-ui.jsx
+++ b/src/client/components/sidebar/transport-ui.jsx
@@ -4,12 +4,7 @@
 import { useRef } from 'react'
 import Tag from '../sftp/transfer-tag'
 import { Flex } from 'antd'
-import {
-  CloseCircleOutlined,
-  PlayCircleOutlined,
-  PauseCircleOutlined,
-  VerticalAlignTopOutlined
-} from '@ant-design/icons'
+import { XCircle, PlayCircle, PauseCircle, ArrowUpToLine } from 'lucide-react'
 import { action } from 'manate'
 import { addClass, removeClass } from '../../common/class'
 import { refsStatic } from '../common/ref'
@@ -145,14 +140,14 @@ export default function Transporter (props) {
     e && e.dataTransfer && e.dataTransfer.clearData()
   }
   const isTransfer = typeTo !== typeFrom
-  const Icon = !pausing ? PauseCircleOutlined : PlayCircleOutlined
+  const Icon = !pausing ? PauseCircle : PlayCircle
   const pauseTitle = pausing ? e('resume') : e('pause')
   const cls = 'sftp-transport mg1b pd1x'
   const typeFromTitle = e(typeFrom)
   const typeToTitle = e(typeTo)
   const title = `${typeFromTitle}→${typeToTitle}: ${fromPath} -> ${toPath} ${speed || ''} ${percent || 0}%`
   const cancelIcon = (
-    <CloseCircleOutlined
+    <XCircle
       className='transfer-control-icon transfer-control-cancel pointer hover-black font14'
       onClick={cancel}
       title={e('cancel')}
@@ -161,7 +156,7 @@ export default function Transporter (props) {
   const toTopIcon = index === 0
     ? null
     : (
-      <VerticalAlignTopOutlined
+      <ArrowUpToLine
         className='transfer-control-icon pointer hover-black font14'
         onClick={moveToTop}
       />


### PR DESCRIPTION
## Summary
- migrate sidebar entry icons and footer utility icons to lucide-react
- keep the existing behavior and layout unchanged while removing direct @ant-design/icons usage in these two areas

## Notes
- scoped to sidebar and footer components only
- shares the lucide-react dependency introduced in #4241

## Testing
- npm run compile