### PR TITLE
Migrate bookmark form icons to lucide-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "iconv-lite": "^0.7.2",
         "json-deep-copy": "1.3.1",
         "jsonwebtoken": "^9.0.1",
+        "lucide-react": "^1.0.1",
         "nanoid": "3.3.8",
         "node-bash": "5.0.1",
         "node-forge": "1.3.3",
@@ -10101,6 +10102,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-1.0.1.tgz",
+      "integrity": "sha512-lih7tKEczCYOQjVEzpFuxEuNzlwf+1yhvlMlEkGWJM3va8Pugv8bYXc/pRtcjPncaP7k84X0Pt/71ufxvqEPtQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/make-fetch-happen": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "iconv-lite": "^0.7.2",
     "json-deep-copy": "1.3.1",
     "jsonwebtoken": "^9.0.1",
+    "lucide-react": "^1.0.1",
     "nanoid": "3.3.8",
     "node-bash": "5.0.1",
     "node-forge": "1.3.3",

--- a/src/client/components/bookmark-form/ai-bookmark-form.jsx
+++ b/src/client/components/bookmark-form/ai-bookmark-form.jsx
@@ -3,17 +3,7 @@
  */
 import { useState, useEffect } from 'react'
 import { Button, Input, message, Space, Alert } from 'antd'
-import {
-  RobotOutlined,
-  LoadingOutlined,
-  CheckOutlined,
-  CloseOutlined,
-  EditOutlined,
-  CopyOutlined,
-  DownloadOutlined,
-  EyeOutlined,
-  ThunderboltOutlined
-} from '@ant-design/icons'
+import { Bot, Loader2, Check, X, Edit, Copy, Download, Eye, Zap } from 'lucide-react'
 import SimpleEditor from '../text-editor/simple-editor'
 import { copy } from '../../common/clipboard'
 import download from '../../common/download'
@@ -265,7 +255,7 @@ export default function AIBookmarkForm (props) {
     type: 'primary',
     onClick: handleGenerate,
     disabled: !description.trim(),
-    icon: loading ? <LoadingOutlined /> : <RobotOutlined />,
+    icon: loading ? <Loader2 /> : <Bot />,
     loading
   }
 
@@ -275,7 +265,7 @@ export default function AIBookmarkForm (props) {
       return null
     }
     return (
-      <Button onClick={handleQuickConnect} icon={<ThunderboltOutlined />}>
+      <Button onClick={handleQuickConnect} icon={<Zap />}>
         {e('quickConnect')}
       </Button>
     )
@@ -288,11 +278,11 @@ export default function AIBookmarkForm (props) {
     footer: (
       <div className='custom-modal-footer-buttons'>
         <Button onClick={handleCancelConfirm}>
-          <CloseOutlined /> {e('cancel')}
+          <X /> {e('cancel')}
         </Button>
         {renderQuickConnectBtn()}
         <Button type='primary' onClick={handleConfirm}>
-          <CheckOutlined /> {e('confirm')}
+          <Check /> {e('confirm')}
         </Button>
       </div>
     ),
@@ -300,19 +290,19 @@ export default function AIBookmarkForm (props) {
   }
 
   const editBtnProps = {
-    icon: editMode ? <EyeOutlined /> : <EditOutlined />,
+    icon: editMode ? <Eye /> : <Edit />,
     title: editMode ? e('preview') : e('edit'),
     onClick: handleToggleEdit
   }
 
   const copyBtnProps = {
-    icon: <CopyOutlined />,
+    icon: <Copy />,
     title: e('copy'),
     onClick: handleCopy
   }
 
   const downloadBtnProps = {
-    icon: <DownloadOutlined />,
+    icon: <Download />,
     title: e('download'),
     onClick: handleSaveToFile
   }
@@ -320,7 +310,7 @@ export default function AIBookmarkForm (props) {
   const cancelProps = {
     onClick: handleCancel,
     title: e('cancel'),
-    icon: <CloseOutlined />,
+    icon: <X />,
     className: 'mg1l'
   }
 
@@ -328,7 +318,7 @@ export default function AIBookmarkForm (props) {
     <div className='ai-bookmark-form pd2'>
       <div className='pd1b ai-bookmark-header'>
         <span className='ai-title'>
-          <RobotOutlined className='mg1r' />
+          <Bot className='mg1r' />
           {e('createBookmarkByAI')}
         </span>
         <HelpIcon link='https://github.com/electerm/electerm/wiki/Create-bookmark-by-AI' />

--- a/src/client/components/bookmark-form/bookmark-from-history-modal.jsx
+++ b/src/client/components/bookmark-form/bookmark-from-history-modal.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react'
 import { Button, message } from 'antd'
-import { PlusOutlined } from '@ant-design/icons'
+import { Plus } from 'lucide-react'
 import Modal from '../common/modal'
 import { refsStatic } from '../common/ref'
 import AICategorySelect from './common/ai-category-select.jsx'
@@ -101,7 +101,7 @@ export default class BookmarkFromHistoryModal extends React.PureComponent {
       open: visible,
       title: (
         <span>
-          <PlusOutlined className='mg1r' />
+          <Plus className='mg1r' />
           {e('bookmarks')}
         </span>
       ),

--- a/src/client/components/bookmark-form/common/connection-hopping.jsx
+++ b/src/client/components/bookmark-form/common/connection-hopping.jsx
@@ -10,10 +10,7 @@ import {
   formItemLayout,
   tailFormItemLayout
 } from '../../../common/form-layout'
-import {
-  MinusCircleFilled,
-  PlusOutlined
-} from '@ant-design/icons'
+import { MinusCircle, Plus } from 'lucide-react'
 import RenderAuth from './render-auth-ssh'
 import uid from '../../../common/uid'
 import {
@@ -115,7 +112,7 @@ export default function renderConnectionHopping (props) {
       dataIndex: 'id',
       render: (id) => {
         return (
-          <MinusCircleFilled
+          <MinusCircle
             className='pointer'
             onClick={() => remove(id)}
           />
@@ -263,7 +260,7 @@ export default function renderConnectionHopping (props) {
           <Button
             type='default'
             htmlType='button'
-            icon={<PlusOutlined />}
+            icon={<Plus />}
             onClick={onSubmit}
           >
             {e('connectionHopping')}

--- a/src/client/components/bookmark-form/common/hex-input.jsx
+++ b/src/client/components/bookmark-form/common/hex-input.jsx
@@ -1,6 +1,6 @@
 import { Input } from 'antd'
 import { useState } from 'react'
-import { CheckOutlined } from '@ant-design/icons'
+import { Check } from 'lucide-react'
 
 export const HexInput = (props) => {
   const [v, setV] = useState((props.value || '').replace('#', ''))
@@ -14,7 +14,7 @@ export const HexInput = (props) => {
   }
   function renderAfter () {
     if (!/^[0-9a-fA-F]{6}$/.test(v)) return null
-    return <CheckOutlined className='pointer' onClick={submit} />
+    return <Check className='pointer' onClick={submit} />
   }
   return (
     <Input

--- a/src/client/components/bookmark-form/common/quick-commands.jsx
+++ b/src/client/components/bookmark-form/common/quick-commands.jsx
@@ -14,7 +14,7 @@ import {
   Button
 } from 'antd'
 import { formItemLayout } from '../../../common/form-layout'
-import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons'
+import { MinusCircle, Plus } from 'lucide-react'
 
 const FormItem = Form.Item
 const FormList = Form.List
@@ -44,7 +44,7 @@ export default function useQuickCmds (form, formData) {
         >
           <Input placeholder={e('quickCommand')} />
         </FormItem>
-        <MinusCircleOutlined onClick={() => remove(field.name)} />
+        <MinusCircle onClick={() => remove(field.name)} />
       </Space>
     )
   }
@@ -68,7 +68,7 @@ export default function useQuickCmds (form, formData) {
                   type='dashed'
                   onClick={() => add()}
                   block
-                  icon={<PlusOutlined />}
+                  icon={<Plus />}
                 >
                   {e('newQuickCommand')}
                 </Button>

--- a/src/client/components/bookmark-form/common/run-scripts.jsx
+++ b/src/client/components/bookmark-form/common/run-scripts.jsx
@@ -5,7 +5,7 @@ import {
   Button,
   Input
 } from 'antd'
-import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons'
+import { MinusCircle, Plus } from 'lucide-react'
 import { formItemLayout } from '../../../common/form-layout'
 
 const FormItem = Form.Item
@@ -15,11 +15,10 @@ const e = window.translate
 export default function renderRunScripts () {
   function renderItem (field, i, add, remove) {
     return (
-      <>
+      <div key={field.key}>
         <Space
           align='baseline'
           className='width-100'
-          key={field.key}
         >
           <FormItem
             label=''
@@ -50,13 +49,13 @@ export default function renderRunScripts () {
               />
             </FormItem>
             <Button
-              icon={<MinusCircleOutlined />}
+              icon={<MinusCircle />}
               onClick={() => remove(field.name)}
               className='mg24b'
             />
           </Space.Compact>
         </Space>
-      </>
+      </div>
     )
   }
 
@@ -82,7 +81,7 @@ export default function renderRunScripts () {
                       script: ''
                     })}
                     block
-                    icon={<PlusOutlined />}
+                    icon={<Plus />}
                   >
                     {e('loginScript')}
                   </Button>

--- a/src/client/components/bookmark-form/common/serial-path-selector.jsx
+++ b/src/client/components/bookmark-form/common/serial-path-selector.jsx
@@ -1,4 +1,4 @@
-import { ReloadOutlined } from '@ant-design/icons'
+import { RefreshCw } from 'lucide-react'
 import { AutoComplete, Spin, Form } from 'antd'
 import { formItemLayout } from '../../../common/form-layout'
 
@@ -31,7 +31,7 @@ export default function SerialPathSelector ({
       </FormItem>
       <Spin spinning={loaddingSerials}>
         <span onClick={store.handleGetSerials} className='pointer'>
-          <ReloadOutlined /> {e('reload')} serials
+          <RefreshCw /> {e('reload')} serials
         </span>
       </Spin>
     </FormItem>

--- a/src/client/components/bookmark-form/common/ssh-tunnels.jsx
+++ b/src/client/components/bookmark-form/common/ssh-tunnels.jsx
@@ -9,7 +9,7 @@ import {
   Table
 } from 'antd'
 import { useState } from 'react'
-import { PlusOutlined, QuestionCircleOutlined, MinusCircleFilled, UserOutlined } from '@ant-design/icons'
+import { Plus, HelpCircle, MinusCircle, User } from 'lucide-react'
 import { formItemLayout, tailFormItemLayout } from '../../../common/form-layout'
 import uid from '../../../common/uid'
 
@@ -113,7 +113,7 @@ export default function renderSshTunnels (props) {
       dataIndex: 'id',
       render: (id) => {
         return (
-          <MinusCircleFilled
+          <MinusCircle
             className='pointer'
             onClick={() => remove(id)}
           />
@@ -149,14 +149,14 @@ export default function renderSshTunnels (props) {
     return (
       <div>
         <p>{e(direction)}</p>
-        <p><UserOutlined /> → {middle} → {last}</p>
+        <p><User /> → {middle} → {last}</p>
       </div>
     )
   }
 
   function renderDynamicForward () {
     return (
-      <p><UserOutlined /> → socks proxy → url</p>
+      <p><User /> → socks proxy → url</p>
     )
   }
 
@@ -224,21 +224,21 @@ export default function renderSshTunnels (props) {
               value='forwardRemoteToLocal'
             >
               <Tooltip title={renderSshTunnelFlow('remoteToLocal')}>
-                <span>R→L <QuestionCircleOutlined /></span>
+                <span>R→L <HelpCircle /></span>
               </Tooltip>
             </RadioButton>
             <RadioButton
               value='forwardLocalToRemote'
             >
               <Tooltip title={renderSshTunnelFlow('localToRemote')}>
-                <span>L→R <QuestionCircleOutlined /></span>
+                <span>L→R <HelpCircle /></span>
               </Tooltip>
             </RadioButton>
             <RadioButton
               value='dynamicForward'
             >
               <Tooltip title={renderDynamicForward()}>
-                <span>{e('dynamicForward')}(socks proxy) <QuestionCircleOutlined /></span>
+                <span>{e('dynamicForward')}(socks proxy) <HelpCircle /></span>
               </Tooltip>
             </RadioButton>
           </RadioGroup>
@@ -286,7 +286,7 @@ export default function renderSshTunnels (props) {
           <Button
             type='default'
             htmlType='button'
-            icon={<PlusOutlined />}
+            icon={<Plus />}
             onClick={onSubmit}
           >
             {e('sshTunnel')}

--- a/src/client/components/bookmark-form/index.jsx
+++ b/src/client/components/bookmark-form/index.jsx
@@ -17,7 +17,7 @@ import {
   terminalSpiceType
 } from '../../common/constants'
 import { createTitleWithTag } from '../../common/create-title'
-import { LoadingOutlined, BookOutlined, RobotOutlined } from '@ant-design/icons'
+import { Loader2, Book, Bot } from 'lucide-react'
 import sessionConfig from './config/session-config'
 import renderForm from './render-form'
 import AIBookmarkForm from './ai-bookmark-form'
@@ -120,7 +120,7 @@ export default class BookmarkIndex2 extends PureComponent {
       <Button
         size='small'
         className='mg2l create-ai-btn'
-        icon={<RobotOutlined />}
+        icon={<Bot />}
         onClick={this.handleToggleAIMode}
       >
         {e('createBookmarkByAI')}
@@ -153,7 +153,7 @@ export default class BookmarkIndex2 extends PureComponent {
     if (!ready) {
       return (
         <div className='pd3 aligncenter'>
-          <LoadingOutlined />
+          <Loader2 />
         </div>
       )
     }
@@ -162,7 +162,7 @@ export default class BookmarkIndex2 extends PureComponent {
     return (
       <div className='form-wrap pd1x'>
         <div className='form-title pd1t pd1x pd2b bold'>
-          <BookOutlined className='mg1r' />
+          <Book className='mg1r' />
           <span>
             {((!isNew ? e('edit') : e('new')) + ' ' + e(settingMap.bookmarks))}
           </span>


### PR DESCRIPTION
## Summary
- migrate bookmark form related icons to lucide-react
- keep existing bookmark form behavior unchanged while updating icon imports in this area only

## Notes
- scoped to bookmark form components only
- shares the lucide-react dependency introduced in #4241

## Testing
- npm run compile