### PR TITLE
fix(session-ssh): resolve issue with macos ssh session input lag

### DIFF
--- a/src/app/server/session-ssh.js
+++ b/src/app/server/session-ssh.js
@@ -483,6 +483,7 @@ class TerminalSshBase extends TerminalBase {
             return reject(err)
           }
           this.channel = channel
+          this.setNoDelay(true)
           globalState.setSession(this.pid, this)
           resolve(this)
         }


### PR DESCRIPTION
### 问题
1. macOS SSH 连接后键盘输入有 ~1s 延迟，macOS 26.1+ 最严重（macOS TCP 栈对 Nagle 实现更严格，延迟可达 200-1000ms）
2. Local zsh 不卡
3. Windows 不卡（Winsock 对交互式连接有特殊优化，延迟小）

### 核心原因
1. setNoDelay(true) 从未在 SSH 会话建立时被调用，导致底层 TCP socket 的 Nagle 算法始终处于启用状态。

注：已在macOS 26.4 & 26.5 上编译并测试通过，ssh 会话卡顿问题已消除