### PR TITLE
fix(mcp-server): add authentication and remove wildcard CORS

### DIFF
--- a/src/app/widgets/widget-mcp-server.js
+++ b/src/app/widgets/widget-mcp-server.js
@@ -11,6 +11,7 @@ const { StreamableHTTPServerTransport } = require('../mcp/server/streamableHttp.
 const { z } = require('../lib/zod')
 const express = require('express')
 const uid = require('../common/uid')
+const crypto = require('crypto')
 const globalState = require('../lib/glob-state')
 const {
   sshBookmarkSchema,
@@ -39,6 +40,12 @@ const widgetInfo = {
       type: 'number',
       default: 30837,
       description: 'The port number to listen on'
+    },
+    {
+      name: 'apiKey',
+      type: 'string',
+      default: '',
+      description: 'API key for authenticating MCP requests. Auto-generated on first start if empty. Clients must send this in the Authorization header as: Bearer <apiKey>'
     },
     {
       name: 'enableBookmarks',
@@ -96,6 +103,10 @@ function getDefaultConfig () {
 class ElectermMCPServer {
   constructor (config) {
     this.config = config
+    // Auto-generate API key if not provided
+    if (!this.config.apiKey) {
+      this.config.apiKey = crypto.randomBytes(32).toString('hex')
+    }
     this.instanceId = uid()
     this.httpServer = null
     this.mcpServer = null
@@ -747,13 +758,36 @@ class ElectermMCPServer {
     const app = express()
     app.use(express.json())
 
-    // Handle CORS
+    // Handle CORS — restrict to same-origin only (no wildcard)
     app.use((req, res, next) => {
-      res.setHeader('Access-Control-Allow-Origin', '*')
+      const allowedOrigin = this.config.allowedOrigin || ''
+      if (allowedOrigin) {
+        res.setHeader('Access-Control-Allow-Origin', allowedOrigin)
+      }
+      // Do NOT set Access-Control-Allow-Origin when no origin is configured
+      // This blocks cross-origin browser requests by default
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id')
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id, Authorization')
       if (req.method === 'OPTIONS') {
         res.status(204).end()
+        return
+      }
+      next()
+    })
+
+    // Authenticate all requests with API key
+    app.use((req, res, next) => {
+      const authHeader = req.headers.authorization || ''
+      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : ''
+      if (!token || token !== this.config.apiKey) {
+        res.status(401).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32600,
+            message: 'Unauthorized: invalid or missing API key'
+          },
+          id: null
+        })
         return
       }
       next()
@@ -838,9 +872,10 @@ class ElectermMCPServer {
         const serverInfo = {
           url: `http://${host}:${port}/mcp`,
           protocol: 'mcp',
-          version: '2024-11-05'
+          version: '2024-11-05',
+          apiKey: self.config.apiKey
         }
-        const msg = `MCP Server is running at ${serverInfo.url}`
+        const msg = `MCP Server is running at ${serverInfo.url} (API key required)`
         resolve({
           serverInfo,
           msg,


### PR DESCRIPTION
## Summary

The MCP server widget (`src/app/widgets/widget-mcp-server.js`) starts an HTTP server on localhost with `Access-Control-Allow-Origin: *` and no authentication. This combination allows any website a user visits to make cross-origin requests to the MCP server endpoints (`/mcp`) and interact with electerm's terminal and SSH bookmark functionality.

This is a permissive cross-origin resource sharing issue (CWE-942). While the server binds to localhost by default, the wildcard CORS header explicitly opts in to cross-origin access from any web page, bypassing the browser's same-origin policy.

## Vulnerability details

**Affected file:** `src/app/widgets/widget-mcp-server.js`
**Affected class:** `ElectermMCPServer`
**Root cause:** Line 752 sets `Access-Control-Allow-Origin: *` with no authentication middleware, meaning any origin can call the MCP server's JSON-RPC endpoints.

**Severity:** Moderate. Exploitation requires the user to have the MCP server widget running and to visit a malicious webpage. However, the MCP server exposes powerful functionality — terminal command execution and SSH bookmark access — so the impact of a successful attack is significant.

**Data flow:**
1. Browser on a malicious page issues `fetch('http://localhost:30837/mcp', ...)` with a JSON-RPC body
2. Express CORS middleware responds with `Access-Control-Allow-Origin: *`, allowing the cross-origin request
3. The request reaches the MCP `StreamableHTTPServerTransport` handler with no authentication check
4. The attacker can invoke any registered MCP tool (e.g., `runTerminalCmd`, `listSshBookmarks`)

## Proof of Concept

A malicious webpage can call the MCP server with no credentials:

```html
<!-- Save as exploit.html and open in a browser while electerm MCP server widget is running -->
<script>
// Step 1: Initialize an MCP session
fetch('http://localhost:30837/mcp', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({
    jsonrpc: '2.0',
    method: 'initialize',
    params: {
      protocolVersion: '2024-11-05',
      capabilities: {},
      clientInfo: { name: 'attacker', version: '1.0' }
    },
    id: 1
  })
})
.then(r => r.json())
.then(data => {
  console.log('MCP session initialized from cross-origin page:', data);
  // The mcp-session-id from the response can be used for further tool calls
  // e.g., listing SSH bookmarks, running terminal commands
})
.catch(e => console.error('Failed (CORS blocked or server not running):', e));
</script>
```

Because the server responds with `Access-Control-Allow-Origin: *`, the browser permits this cross-origin request and the attacker receives the full response.

## Fix description

This PR makes two changes:

1. **Removes wildcard CORS.** The `Access-Control-Allow-Origin: *` header is no longer sent by default. An optional `allowedOrigin` config field lets users explicitly whitelist a specific origin if needed for their workflow. When unconfigured, no `Access-Control-Allow-Origin` header is sent, so browsers block cross-origin requests entirely.

2. **Adds Bearer token authentication.** A 256-bit random API key is auto-generated on first start (via `crypto.randomBytes(32)`) and stored in the widget config. Every request must include `Authorization: Bearer <apiKey>`. The key is displayed in the server info so legitimate MCP clients can use it. This provides defense-in-depth — even if CORS were somehow bypassed, requests without the key are rejected with 401.

The `Authorization` header is added to `Access-Control-Allow-Headers` so preflight requests work correctly for authenticated clients.

## Testing

- Verified the diff is minimal (1 file changed, 40 insertions, 5 deletions)
- Confirmed `crypto.randomBytes` generates a cryptographically secure token
- Confirmed the auth middleware runs before any MCP handler via Express middleware ordering
- Confirmed the API key is surfaced in `serverInfo` so legitimate clients can authenticate
- Confirmed that without the `Access-Control-Allow-Origin` header, browsers will block cross-origin fetch responses by default

## Adversarial review

Before submitting, we considered whether this finding could be dismissed: the server binds to localhost only, so remote network access is not possible. However, the threat model for localhost services with wildcard CORS is well-established — any webpage the user visits becomes a potential attacker. The browser's same-origin policy is the primary defense for localhost services, and `Access-Control-Allow-Origin: *` explicitly disables it. There is no existing authentication or session validation that would prevent exploitation. Given that the MCP server exposes terminal command execution, the impact justifies the fix.