### PR TITLE
Change deb architecture from loongarch64 to loong64

### DIFF
--- a/build/bin/build-linux-loong64.sh
+++ b/build/bin/build-linux-loong64.sh
@@ -367,7 +367,7 @@ Package: electerm
 Version: ${electerm_version}
 Section: utils
 Priority: optional
-Architecture: loongarch64
+Architecture: loong64
 Depends: libglib2.0-0, libnss3, libnspr4, libdbus-1-3, libatk1.0-0, libatk-bridge2.0-0, libcups2, libcairo2, libpango-1.0-0, libx11-6, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxrandr2, libxkbcommon0, libdrm2, libgbm1, libatspi2.0-0, libpulse0, libgtk-3-0
 Maintainer: ZHAO Xudong <zxdong@gmail.com>
 Description: Open-sourced terminal/ssh/sftp/telnet/serialport/RDP/VNC/Spice/ftp client


### PR DESCRIPTION
Debian对loongarch64的标记为 loong64。将构建脚本中的架构表示修改为Debian对应的标识以确保构建出的deb能在debian中正确安装。

Closes #4344 