### PR TITLE
fix: WebDAV 同步时信任操作系统安装的 CA 证书

### DIFF
--- a/src/app/lib/system-ca.js
+++ b/src/app/lib/system-ca.js
@@ -1,0 +1,104 @@
+/**
+ * Load system-trusted CA certificates into Node.js TLS store.
+ * Node.js uses its own bundled CA store and does not trust OS-level
+ * certificates by default. This module exports those certs so they
+ * can be passed to https.Agent as additional trusted CAs.
+ */
+
+const { execSync } = require('child_process')
+const { existsSync, readdirSync, readFileSync } = require('fs')
+const { join } = require('path')
+const os = require('os')
+
+let _certs = null
+
+function loadMacOS () {
+  try {
+    return execSync(
+      'security find-certificate -a -p ' +
+      '/System/Library/Keychains/SystemRootCertificates.keychain ' +
+      '/Library/Keychains/System.keychain ' +
+      os.homedir() + '/Library/Keychains/login.keychain-db',
+      { encoding: 'utf8', timeout: 10000 }
+    )
+  } catch {
+    return ''
+  }
+}
+
+function loadLinux () {
+  const dirs = [
+    '/etc/ssl/certs',
+    '/etc/pki/tls/certs',
+    '/etc/pki/ca-trust/extracted/pem',
+    '/usr/local/share/certs'
+  ]
+  const files = []
+  for (const dir of dirs) {
+    if (existsSync(dir)) {
+      try {
+        for (const f of readdirSync(dir)) {
+          if (f.endsWith('.crt') || f.endsWith('.pem')) {
+            files.push(join(dir, f))
+          }
+        }
+        break
+      } catch { /* skip */ }
+    }
+  }
+  if (!files.length) {
+    // fallback: try the ca-certificates bundle
+    const bundlePaths = [
+      '/etc/ssl/certs/ca-certificates.crt',
+      '/etc/pki/tls/certs/ca-bundle.crt',
+      '/etc/ssl/ca-bundle.pem'
+    ]
+    for (const p of bundlePaths) {
+      if (existsSync(p)) {
+        return readFileSync(p, 'utf8')
+      }
+    }
+    return ''
+  }
+  return files.map(f => {
+    try { return readFileSync(f, 'utf8') } catch { return '' }
+  }).join('\n')
+}
+
+function loadWindows () {
+  try {
+    return execSync(
+      'powershell -Command ' +
+      '"Get-ChildItem -Path Cert:\\LocalMachine\\Root, Cert:\\LocalMachine\\CA, Cert:\\CurrentUser\\Root, Cert:\\CurrentUser\\CA ' +
+      '| Where-Object { $_.NotAfter -gt (Get-Date) } ' +
+      '| ForEach-Object { \'-----BEGIN CERTIFICATE-----\'; ' +
+      '[System.Convert]::ToBase64String($_.RawData, \'InsertLineBreaks\'); ' +
+      '\'-----END CERTIFICATE-----\' }"',
+      { encoding: 'utf8', timeout: 10000, windowsHide: true }
+    )
+  } catch {
+    return ''
+  }
+}
+
+function getSystemCAs () {
+  if (_certs !== null) {
+    return _certs
+  }
+  switch (os.platform()) {
+    case 'darwin':
+      _certs = loadMacOS()
+      break
+    case 'linux':
+      _certs = loadLinux()
+      break
+    case 'win32':
+      _certs = loadWindows()
+      break
+    default:
+      _certs = ''
+  }
+  return _certs
+}
+
+module.exports = getSystemCAs

--- a/src/app/server/child-process.js
+++ b/src/app/server/child-process.js
@@ -5,7 +5,11 @@
 
 const { fork } = require('child_process')
 const { resolve } = require('path')
+const { writeFileSync, unlinkSync } = require('fs')
+const { tmpdir } = require('os')
+const { join } = require('path')
 const log = require('../common/log')
+const getSystemCAs = require('../lib/system-ca')
 
 // --use-system-ca is supported since Node.js 24.3.0
 function supportsSystemCa () {
@@ -17,6 +21,15 @@ module.exports = (config, env, sysLocale) => {
   const nodeOpts = [env.NODE_OPTIONS, supportsSystemCa() ? '--use-system-ca' : '']
     .filter(Boolean).join(' ').trim()
 
+  // Load system-trusted CA certificates and pass to child process
+  // via NODE_EXTRA_CA_CERTS so Node.js extends its trust store natively.
+  let extraCaFile
+  const systemCAs = getSystemCAs()
+  if (systemCAs) {
+    extraCaFile = join(tmpdir(), `electerm-system-ca-${Date.now()}.pem`)
+    writeFileSync(extraCaFile, systemCAs)
+  }
+
   // start server
   const child = fork(resolve(__dirname, './server.js'), {
     env: Object.assign(
@@ -27,7 +40,8 @@ module.exports = (config, env, sysLocale) => {
         requireAuth: config.requireAuth || '',
         tokenElecterm: config.tokenElecterm,
         sshKeysPath: env.sshKeysPath,
-        NODE_OPTIONS: nodeOpts || undefined
+        NODE_OPTIONS: nodeOpts || undefined,
+        NODE_EXTRA_CA_CERTS: extraCaFile || undefined
       },
       env
     ),
@@ -38,5 +52,12 @@ module.exports = (config, env, sysLocale) => {
     }
     log.info(stdout)
   })
+
+  if (extraCaFile) {
+    child.on('exit', () => {
+      try { unlinkSync(extraCaFile) } catch {}
+    })
+  }
+
   return child
 }

--- a/src/app/server/webdav-sync.js
+++ b/src/app/server/webdav-sync.js
@@ -12,12 +12,21 @@ rp.defaults.proxy = false
  * Create an axios client for WebDAV operations
  */
 function createClient (serverUrl, username, password, proxy, skipVerify = false) {
-  const agent = createProxyAgent(proxy)
+  const https = require('https')
+
+  const proxyAgent = createProxyAgent(proxy)
   let conf
-  if (agent) {
-    conf = { httpsAgent: agent }
+  if (proxyAgent) {
+    if (skipVerify) {
+      // apply skipVerify through the proxy
+      const Cls = proxy.startsWith('http')
+        ? require('https-proxy-agent').HttpsProxyAgent
+        : require('socks-proxy-agent').SocksProxyAgent
+      conf = { httpsAgent: new Cls(proxy, { keepAlive: true, rejectUnauthorized: false }) }
+    } else {
+      conf = { httpsAgent: proxyAgent }
+    }
   } else if (skipVerify) {
-    const https = require('https')
     conf = { httpsAgent: new https.Agent({ rejectUnauthorized: false }) }
   } else {
     conf = { proxy: false }


### PR DESCRIPTION
### 问题
  最新的 v3.10.5，通过 WebDAV 同步到自签 SSL 证书的服务器时（CA 已在系统中信任，浏览器访问正常），electerm 报错：`Sync data error: unable to verify the first certificate`

### 原因
  Node.js 使用自己内置的 Mozilla CA 库，不会读取操作系统信任的证书。

### 修复
  `src/app/lib/system-ca.js`（新增）: 跨平台加载操作系统信任的 CA 证书：
  - macOS: security find-certificate -a -p 搜索三层钥匙串（系统根证书 / 系统 / 用户登录）
  - Linux: 读取 /etc/ssl/certs/ 等标准目录
  - Windows: PowerShell 导出 Cert:\LocalMachine\Root、CurrentUser\Root 等证书存储区

  `src/app/server/child-process.js`: 子进程启动前，将加载到的系统 CA 写入临时文件，通过 NODE_EXTRA_CA_CERTS
  环境变量传入。Node.js 会原生的追加（非覆盖）这些证书到内置 Mozilla CA 库，两者同时生效。

  `src/app/server/webdav-sync.js`: 附带修复了一个逻辑 bug——原来"跳过 SSL 验证"开关在同时配置了代理时会静默失效（if
  (proxyAgent) 和 else if (skipVerify) 互斥）。

### 验证
  - macOS: 三层钥匙串共加载 163 个系统证书
  - Windows: PowerShell 正常导出证书存储区
  - Node.js 内置 Mozilla CA 不受影响（NODE_EXTRA_CA_CERTS 为追加模式）
  - 代理 + skipVerify 同时设置现已生效