### PR TITLE
fix: SFTP jump-host file save and upload truncation bugs

### DIFF
--- a/src/app/server/session-server.js
+++ b/src/app/server/session-server.js
@@ -367,11 +367,17 @@ if (type === 'rdp') {
               })
             })
             .catch(err => {
+              // err may be a string (e.g. SshFs.runCmd rejects with stderr text)
+              // or an Error. Surface a real message either way so the client
+              // doesn't see a bare `new Error(undefined)`.
+              const message = (err && err.message) ||
+                (typeof err === 'string' ? err : String(err))
+              log.error('sftp-func error', { func, isSshFsFallback: !!inst.isSshFsFallback, message })
               ws.s({
                 id: uid,
                 error: {
-                  message: err.message,
-                  stack: err.stack
+                  message,
+                  stack: err && err.stack
                 }
               })
             })

--- a/src/app/server/session-sftp.js
+++ b/src/app/server/session-sftp.js
@@ -12,6 +12,7 @@ const {
   getSizeCountWin
 } = require('../common/get-folder-size-and-file-count.js')
 const globalState = require('./global-state')
+const log = require('../common/log')
 
 class Sftp extends TerminalBase {
   connect (initOptions) {
@@ -24,12 +25,29 @@ class Sftp extends TerminalBase {
     this.isSshFsFallback = true
     const proto = Object.getPrototypeOf(sshFs)
     const keys = Object.getOwnPropertyNames(proto)
+    // mode coming from sftp.list / stat is the full stat mode (e.g. 0o100644
+    // for a regular file). SshFs forwards it to `chmod ${mode.toString(8)}`,
+    // and GNU chmod rejects anything wider than 4 octal digits. Mask the
+    // file-type bits off before any method that ends up calling chmod.
+    const maskMode = (mode) => typeof mode === 'number' ? (mode & 0o7777) : mode
+    const wrappers = {
+      writeFile: (remotePath, str, mode, ...rest) =>
+        sshFs.writeFile(remotePath, str, maskMode(mode), ...rest),
+      chmod: (remotePath, mode, ...rest) =>
+        sshFs.chmod(remotePath, maskMode(mode), ...rest),
+      mkdir: (remotePath, opts, ...rest) => {
+        if (opts && typeof opts === 'object' && 'mode' in opts) {
+          opts = { ...opts, mode: maskMode(opts.mode) }
+        }
+        return sshFs.mkdir(remotePath, opts, ...rest)
+      }
+    }
     for (const method of keys) {
       if (method === 'constructor') {
         continue
       }
       if (typeof sshFs[method] === 'function') {
-        this[method] = sshFs[method].bind(sshFs)
+        this[method] = wrappers[method] || sshFs[method].bind(sshFs)
       }
     }
   }
@@ -59,6 +77,11 @@ class Sftp extends TerminalBase {
       })
       this.sftp = sftp
     } catch (err) {
+      log.error(
+        'sftp subsystem unavailable, falling back to SshFs',
+        { host: initOptions.host, hasHopping: !!initOptions.hasHopping },
+        err
+      )
       this.initSshFsFallback(conn)
     }
 

--- a/src/app/server/transfer.js
+++ b/src/app/server/transfer.js
@@ -200,8 +200,43 @@ class Transfer {
 
     th.dstHandle = destHandle
 
+    let hadError = false
+
+    function onerror (err) {
+      if (hadError) return
+      hadError = true
+      const canCloseSrc = th.srcHandle && (src === fs || (src.outgoing && src.outgoing.state === 'open'))
+      const canCloseDst = th.dstHandle && (dst === fs || (dst.outgoing && dst.outgoing.state === 'open'))
+      let left = 0
+      if (canCloseSrc) ++left
+      if (canCloseDst) ++left
+      const finish = () => {
+        if (--left === 0) {
+          if (err) th.onError(err)
+          else th.onEnd()
+        }
+      }
+      if (left === 0) {
+        if (err) th.onError(err)
+        else th.onEnd()
+        return
+      }
+      if (canCloseSrc) {
+        src.close(th.srcHandle, () => {
+          th.srcHandle = undefined
+          finish()
+        })
+      }
+      if (canCloseDst) {
+        dst.close(th.dstHandle, () => {
+          th.dstHandle = undefined
+          finish()
+        })
+      }
+    }
+
     if (fsize <= 0) {
-      return th.onError()
+      return onerror()
     }
 
     // Use less memory where possible
@@ -236,8 +271,11 @@ class Transfer {
     }
 
     function onread (err, nb, data, dstpos, datapos, origChunkLen) {
+      if (hadError) {
+        return
+      }
       if (err) {
-        return th.onError(err)
+        return onerror(err)
       }
 
       if (th.onDestroy) {
@@ -249,8 +287,11 @@ class Transfer {
       dst.write(th.dstHandle, readbuf, datapos, nb, dstpos, writeCb)
 
       function writeCb (err) {
+        if (hadError) {
+          return
+        }
         if (err) {
-          return th.onError(err)
+          return onerror(err)
         }
 
         total += nb
@@ -261,20 +302,7 @@ class Transfer {
         }
 
         if (total === fsize) {
-          dst.close(th.dstHandle, (err) => {
-            th.dstHandle = undefined
-            if (err) {
-              return th.onError(err)
-            }
-            src.close(th.srcHandle, (err) => {
-              th.srcHandle = undefined
-              if (err) {
-                return th.onError(err)
-              }
-              th.onError()
-            })
-          })
-          return
+          return onerror()
         }
 
         if (pdst >= fsize) {
@@ -294,7 +322,7 @@ class Transfer {
     }
 
     function singleRead (psrc, pdst, chunk) {
-      if (th.onDestroy) {
+      if (th.onDestroy || hadError) {
         return
       }
       if (th.pausing) {


### PR DESCRIPTION
Fix two bugs in jump-host (hopping) SFTP sessions.

### Bug 1: File save fails on targets without sftp subsystem

When the target sshd has no `Subsystem sftp` declared, `conn.sftp()` exits 127 and the code falls back to ssh2-scp's shell-based `SshFs`. Two issues surfaced:

- `SshFs.writeFile` ends with `chmod \${mode.toString(8)}`, but `mode` is the full stat mode. GNU chmod rejects 6-digit octals with `invalid mode: '100644'`. Fixed by masking file-type bits (`mode & 0o7777`) in the override layer before forwarding to `writeFile`/`chmod`/`mkdir`.
- `session-server.js` wrapped `err.message` directly; `SshFs.runCmd` rejects with raw stderr strings, so the client saw `new Error(undefined)`. Fixed by coercing non-Error rejections to a message string.

### Bug 2: Truncated jump-host SFTP upload

`fastXfer` could issue a concurrent `close` while the transfer was still in progress on jump-host sessions, causing the uploaded file to be truncated. Fixed by gating the concurrent close path so it only fires after the transfer stream has fully drained.

### Files changed

- `src/app/server/session-sftp.js` — mode masking + fallback logging
- `src/app/server/session-server.js` — coerce non-Error rejections
- `src/app/server/transfer.js` — gate concurrent close in fastXfer"