### PR TITLE
Add configurable Shift+Enter hotkey for terminal line continuation

### DIFF
--- a/src/app/common/default-setting.js
+++ b/src/app/common/default-setting.js
@@ -42,6 +42,7 @@ module.exports = exports.default = {
   addTimeStampToTermLog: false,
   keepaliveInterval: 10000,
   backspaceMode: '^?',
+  shiftEnterMode: '\\\\\\n',
   showHiddenFilesOnSftpStart: true,
   terminalInfos: [
     'uptime',

--- a/src/client/common/default-setting.js
+++ b/src/client/common/default-setting.js
@@ -48,6 +48,7 @@ export default {
   sftpPathFollowSsh: false,
   keepaliveInterval: 10000,
   backspaceMode: '^?',
+  shiftEnterMode: '\\\\\\n',
   showHiddenFilesOnSftpStart: true,
   terminalInfos: [
     'uptime',

--- a/src/client/components/setting-panel/setting-terminal.jsx
+++ b/src/client/components/setting-panel/setting-terminal.jsx
@@ -552,6 +552,10 @@ export default class SettingTerminal extends Component {
         {
           this.renderText('terminalWordSeparator', e('terminalWordSeparator'))
         }
+        <div className='pd1b'>Shift+Enter</div>
+        {
+          this.renderText('shiftEnterMode', 'Enter the text to send when hotkey is pressed. (e.g., \\\\\\n)')
+        }
         {
           this.renderCursorStyleSelect()
         }

--- a/src/client/components/shortcuts/shortcut-handler.js
+++ b/src/client/components/shortcuts/shortcut-handler.js
@@ -5,6 +5,30 @@ import {
 } from '../../common/constants'
 import keyControlPressed from '../../common/key-control-pressed.js'
 
+function processEscapeSequences (text) {
+  let result = ''
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '\\' && i + 1 < text.length) {
+      const next = text[i + 1]
+      if (next === 'n') {
+        result += '\n'
+      } else if (next === 't') {
+        result += '\t'
+      } else if (next === 'r') {
+        result += '\r'
+      } else if (next === '\\') {
+        result += '\\'
+      } else {
+        result += '\\' + next
+      }
+      i++
+    } else {
+      result += text[i]
+    }
+  }
+  return result
+}
+
 function sendInputData (ctx, data) {
   if (!data) return
   if (ctx.attachAddon && ctx.attachAddon._sendData) {
@@ -168,6 +192,21 @@ export function shortcutExtend (Cls) {
       const altDelDelKey = delKey === 8 ? 127 : 8
       const char = String.fromCharCode(shiftKey ? delKey : altDelDelKey)
       this.socket.send(char)
+      this.term.scrollToBottom()
+      return false
+    } else if (
+      this.term &&
+      key === 'Enter' &&
+      type === 'keydown' &&
+      shiftKey &&
+      !ctrlKey &&
+      !altKey &&
+      !metaKey
+    ) {
+      event.preventDefault()
+      event.stopPropagation()
+      const shiftEnterText = processEscapeSequences(this.props.config.shiftEnterMode || '\\\\\n')
+      this.socket.send(shiftEnterText)
       this.term.scrollToBottom()
       return false
     } else if (


### PR DESCRIPTION
Send a customizable escape sequence when Shift+Enter is pressed in the terminal. 
Defaults to backslash + newline for shell line continuation. 
Users can change the sent text in Settings > Terminal via an input field that supports escape notation (\n, \t, \).