### PR TITLE
Add MiniMax AI presets for global and China endpoints

### DIFF
--- a/src/client/components/ai/ai-config-props.js
+++ b/src/client/components/ai/ai-config-props.js
@@ -76,6 +76,38 @@ export const defaultAIPresets = [
     authHeaderNameAI: 'Authorization: Bearer'
   },
   {
+    id: 'minimax-global-m3',
+    nameAI: 'MiniMax (Global, MiniMax-M3)',
+    baseURLAI: 'https://api.minimax.io/v1',
+    apiPathAI: '/chat/completions',
+    modelAI: 'MiniMax-M3',
+    authHeaderNameAI: 'Authorization: Bearer'
+  },
+  {
+    id: 'minimax-global-m27',
+    nameAI: 'MiniMax (Global, MiniMax-M2.7)',
+    baseURLAI: 'https://api.minimax.io/v1',
+    apiPathAI: '/chat/completions',
+    modelAI: 'MiniMax-M2.7',
+    authHeaderNameAI: 'Authorization: Bearer'
+  },
+  {
+    id: 'minimax-cn-m3',
+    nameAI: 'MiniMax (China, MiniMax-M3)',
+    baseURLAI: 'https://api.minimaxi.com/v1',
+    apiPathAI: '/chat/completions',
+    modelAI: 'MiniMax-M3',
+    authHeaderNameAI: 'Authorization: Bearer'
+  },
+  {
+    id: 'minimax-cn-m27',
+    nameAI: 'MiniMax (China, MiniMax-M2.7)',
+    baseURLAI: 'https://api.minimaxi.com/v1',
+    apiPathAI: '/chat/completions',
+    modelAI: 'MiniMax-M2.7',
+    authHeaderNameAI: 'Authorization: Bearer'
+  },
+  {
     id: 'xai',
     nameAI: 'xAI (Grok)',
     baseURLAI: 'https://api.x.ai/v1',

--- a/test/unit-ci/ai-config-presets.spec.js
+++ b/test/unit-ci/ai-config-presets.spec.js
@@ -1,0 +1,49 @@
+const { describe, test } = require('node:test')
+const assert = require('node:assert/strict')
+
+describe('AI configuration presets', () => {
+  test('includes MiniMax models for both supported regions', async () => {
+    const { defaultAIPresets } = await import('../../src/client/components/ai/ai-config-props.js')
+    const presets = defaultAIPresets.filter(preset => preset.id.startsWith('minimax-'))
+
+    assert.deepEqual(
+      presets.map(({ id, baseURLAI, apiPathAI, modelAI, authHeaderNameAI }) => ({
+        id,
+        baseURLAI,
+        apiPathAI,
+        modelAI,
+        authHeaderNameAI
+      })),
+      [
+        {
+          id: 'minimax-global-m3',
+          baseURLAI: 'https://api.minimax.io/v1',
+          apiPathAI: '/chat/completions',
+          modelAI: 'MiniMax-M3',
+          authHeaderNameAI: 'Authorization: Bearer'
+        },
+        {
+          id: 'minimax-global-m27',
+          baseURLAI: 'https://api.minimax.io/v1',
+          apiPathAI: '/chat/completions',
+          modelAI: 'MiniMax-M2.7',
+          authHeaderNameAI: 'Authorization: Bearer'
+        },
+        {
+          id: 'minimax-cn-m3',
+          baseURLAI: 'https://api.minimaxi.com/v1',
+          apiPathAI: '/chat/completions',
+          modelAI: 'MiniMax-M3',
+          authHeaderNameAI: 'Authorization: Bearer'
+        },
+        {
+          id: 'minimax-cn-m27',
+          baseURLAI: 'https://api.minimaxi.com/v1',
+          apiPathAI: '/chat/completions',
+          modelAI: 'MiniMax-M2.7',
+          authHeaderNameAI: 'Authorization: Bearer'
+        }
+      ]
+    )
+  })
+})


### PR DESCRIPTION
Reason: Add MiniMax provider and model presets to the existing AI provider registry.

## Summary
- Add global and China presets for MiniMax-M3 and MiniMax-M2.7.
- Configure each preset with the regional chat completion endpoint and bearer authentication.
- Add unit coverage for the complete preset matrix.

## Checks
- `node --test test/unit-ci/ai-config-presets.spec.js`
- `npm run test-unit-ci`
- `npm run lint`