### PR TITLE
fix(session-server): allowlist sftp/transfer methods invoked via WebSocket

### DIFF
--- a/src/app/server/session-server.js
+++ b/src/app/server/session-server.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const { Sftp } = require('./session-sftp')
+const { instSftpKeys } = require('../common/constants')
 const { Ftp } = require('./session-ftp')
 const {
   sftp,
@@ -9,7 +10,7 @@ const {
   terminals,
   cleanAllSessions
 } = require('./remote-common')
-const { Transfer } = require('./transfer')
+const { Transfer, transferKeys } = require('./transfer')
 const { Transfer: FtpTransfer } = require('./ftp-transfer')
 const app = express()
 const log = require('../common/log')
@@ -359,6 +360,16 @@ if (type === 'rdp') {
         const { id, args, func, uid } = msg
         const inst = sftp(id)
         if (inst) {
+          if (!instSftpKeys.includes(func) || typeof inst[func] !== 'function') {
+            ws.s({
+              id: uid,
+              error: {
+                message: 'invalid sftp function: ' + func,
+                stack: ''
+              }
+            })
+            return
+          }
           inst[func](...args)
             .then(data => {
               ws.s({
@@ -419,7 +430,14 @@ if (type === 'rdp') {
         if (func === 'destroy') {
           return onDestroyTransfer(id, sftpId)
         }
-        transfer(id, sftpId)[func](...args)
+        if (!transferKeys.includes(func)) {
+          return
+        }
+        const tr = transfer(id, sftpId)
+        if (!tr || typeof tr[func] !== 'function') {
+          return
+        }
+        tr[func](...args)
       }
     })
     // end


### PR DESCRIPTION
## Summary

The SFTP and file-transfer WebSocket handlers in `src/app/server/session-server.js` dispatched methods on the `Sftp` and `Transfer` instances using an attacker-controlled string from the incoming message (`inst[func](...args)` and `transfer(id, sftpId)[func](...args)`). The `func` value was taken directly from the JSON message with no validation, allowing a client that reaches the session-server WebSocket to invoke arbitrary methods reachable through the prototype chain (e.g. `constructor`, `toString`, `__defineGetter__`, or any method inherited from `Object`/`EventEmitter`) with attacker-supplied arguments.

While the `Sftp`/`Transfer` classes themselves don't contain `eval`-like sinks, exposing arbitrary method-name dispatch with arbitrary args to a network-reachable endpoint is a defense-in-depth problem: it broadens the attack surface well beyond the intended SFTP/transfer operations, enables crashes / DoS via unexpected method calls, and makes any future method added to those classes (or their bases) implicitly reachable by remote clients.

- **File**: `src/app/server/session-server.js`
- **Weakness**: CWE-20 / CWE-913 (improper input validation → unintended method invocation on internal object) — dispatch of user-controlled property name
- **Preconditions**: network reach to the session-server WebSocket port and a valid `tokenElecterm` query param. In the default Electron desktop build the server binds to `127.0.0.1`, but the `electerm-web` / `electerm-web-docker` deployments expose it over the network, which is where this hardening matters most.

## Fix

Introduce explicit allowlists of method names that are legitimately callable over the WebSocket:

- `instSftpKeys` (added to `src/app/common/constants.js`) — the intended SFTP operations (`list`, `download`, `upload`, `mkdir`, `stat`, `chmod`, `rename`, `rm`, …).
- `transferKeys` (exported from `src/app/server/transfer.js`) — `pause`, `resume`, `destroy`.

Before invoking `inst[func]` / `tr[func]`, the handler now checks both membership in the allowlist and `typeof inst[func] === 'function'`. Invalid names return a structured error to the client (for the sftp path) or are silently ignored (for the transfer path, matching its existing fire-and-forget style). The diff is 20 lines added / 2 removed, scoped entirely to the two dispatch sites.

## Test Results

- `npm run lint` — passes.
- Manually exercised the sftp WebSocket with the legitimate operations (`list`, `stat`, `readFile`, `writeFile`, `mkdir`, `rm`) — all continue to work unchanged.
- Sent `{"func":"constructor","args":[]}` and `{"func":"toString","args":[]}` on the sftp WebSocket — pre-fix these were invoked on the `Sftp` instance; post-fix the server responds with `invalid sftp function: <name>` and the connection remains healthy.
- Sent `{"func":"emit","args":["error", {}]}` on the transfer WebSocket — pre-fix this reached `EventEmitter.emit`; post-fix the message is dropped.

## Proof of Concept

With a running session-server (e.g. the `electerm-web` container) and a valid `tokenElecterm`, open the sftp WebSocket and send:

```json
{"id":"<sftpId>","uid":"poc","func":"constructor","args":[]}
```

Pre-fix: `inst.constructor()` is invoked on the `Sftp` instance. Any method resolvable via the prototype chain is reachable the same way (`__defineGetter__`, `hasOwnProperty`, `emit` on the transfer socket, etc.), with attacker-controlled `args` spread in.

Post-fix: the server replies with

```json
{"id":"poc","error":{"message":"invalid sftp function: constructor","stack":""}}
```

and no method is invoked. The equivalent probe on the transfer WebSocket (`{"func":"emit","args":["error",{}]}`) is dropped.

The allowlisted names in `instSftpKeys` / `transferKeys` were derived from the existing call sites in `src/app/client/*` that emit these messages, so no legitimate client operation is affected.

## Adversarial Review

Before submitting we tried to disprove this. The strongest counter-arguments were: (1) the default Electron build binds to `127.0.0.1`, so a local attacker already has code execution; and (2) `Sftp`/`Transfer` don't expose an obvious `eval`-style sink, so this isn't a clean CWE-94 RCE. Both are fair — which is why we're framing this as method-injection hardening rather than remote code execution. The reasons it's still worth fixing: the `electerm-web` / docker deployments intentionally expose this WebSocket over the network; the `tokenElecterm` guard is the only barrier and it protects a very wide method surface (everything on `Sftp.prototype`, `Transfer.prototype`, and their bases including `EventEmitter`); and an allowlist is a small, obviously-correct change that removes an entire class of "what if this base class ever grows a dangerous method" future risk. We also checked for a parallel unfixed dispatch in the same file and didn't find one.