### PR TITLE
Fix window restoration across multiple displays

### DIFF
--- a/src/app/lib/window-control.js
+++ b/src/app/lib/window-control.js
@@ -6,10 +6,10 @@ const lastStateManager = require('./last-state')
 const {
   isDev,
   minWindowWidth,
-  minWindowHeight,
-  isLinux
+  minWindowHeight
 } = require('../common/runtime-constants')
 const globalState = require('./glob-state')
+const { restoreWindowBounds } = require('./window-restore')
 
 exports.getScreenCurrent = () => {
   const rect = globalState.get('win')
@@ -51,74 +51,21 @@ exports.unmaximize = () => {
 }
 
 exports.getWindowSize = async () => {
-  const rect = await exports.getWindowSizeDep()
-  if (!isLinux) {
-    return rect
-  }
-  const {
-    width,
-    height
-  } = exports.getScreenSize()
-  if (rect.width >= width - 200) {
-    rect.width = width - 200
-    rect.x = 100
-  }
-  if (rect.height >= height - 200) {
-    rect.height = height - 200
-    rect.y = 100
-  }
-  return rect
+  return exports.getWindowSizeDep()
 }
 
 exports.getWindowSizeDep = async () => {
   const windowSizeLastState = await lastStateManager.get('windowSize')
   const windowPosLastState = await lastStateManager.get('windowPos')
-  const {
-    width: maxWidth,
-    height: maxHeight
-  } = exports.getScreenSize()
-  if (!windowSizeLastState || isDev) {
-    return {
-      width: maxWidth,
-      height: maxHeight,
-      x: 0,
-      y: 0
-    }
-  }
-  const {
-    innerWidth,
-    height,
-    screenHeight,
-    screenWidth
-  } = windowSizeLastState
-  const fw = innerWidth / screenWidth
-  const fh = height / screenHeight
-  let w = maxWidth * fw
-  let h = maxHeight * fh
-  const minW = minWindowWidth
-  const minH = minWindowHeight
-  if (w < minW) {
-    w = minW
-  }
-  if (h < minH) {
-    h = minH
-  }
-  let {
-    x = 0,
-    y = 0
-  } = windowPosLastState || {}
-  if (x < 0 || x > maxWidth - 100) {
-    x = 0
-  }
-  if (y < 0 || y > maxHeight - 100) {
-    y = 0
-  }
-  return {
-    width: w,
-    height: h,
-    x,
-    y
-  }
+  const { screen } = require('electron')
+  return restoreWindowBounds({
+    screen,
+    windowSizeLastState,
+    windowPosLastState,
+    isDev,
+    minWindowWidth,
+    minWindowHeight
+  })
 }
 
 exports.setWindowPos = (pos) => {

--- a/src/app/lib/window-restore.js
+++ b/src/app/lib/window-restore.js
@@ -1,0 +1,86 @@
+const minVisibleSize = 100
+
+function clamp (value, min, max) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function finiteOr (value, fallback) {
+  return Number.isFinite(value) ? value : fallback
+}
+
+function limitWindowSize (savedSize, savedScreenSize, workAreaSize, minSize) {
+  const ratio = savedSize / savedScreenSize
+  const restoredSize = Number.isFinite(ratio) && ratio > 0
+    ? workAreaSize * ratio
+    : workAreaSize
+  return Math.min(Math.max(Math.round(restoredSize), minSize), workAreaSize)
+}
+
+function limitWindowPosition (position, workAreaPosition, workAreaSize, windowSize) {
+  const visibleSize = Math.min(minVisibleSize, windowSize, workAreaSize)
+  const min = workAreaPosition - windowSize + visibleSize
+  const max = workAreaPosition + workAreaSize - visibleSize
+  return clamp(position, min, max)
+}
+
+exports.restoreWindowBounds = ({
+  screen,
+  windowSizeLastState,
+  windowPosLastState,
+  isDev,
+  minWindowWidth,
+  minWindowHeight
+}) => {
+  const defaultBounds = {
+    x: 0,
+    y: 0,
+    width: minWindowWidth,
+    height: minWindowHeight
+  }
+
+  if (!windowSizeLastState || isDev) {
+    const { workArea } = screen.getDisplayMatching(defaultBounds)
+    return {
+      width: workArea.width,
+      height: workArea.height,
+      x: 0,
+      y: 0
+    }
+  }
+
+  const savedPosition = {
+    x: finiteOr(windowPosLastState && windowPosLastState.x, 0),
+    y: finiteOr(windowPosLastState && windowPosLastState.y, 0)
+  }
+  // Electron reports display bounds and window positions in DIP coordinates.
+  const { workArea } = screen.getDisplayNearestPoint(savedPosition)
+  const width = limitWindowSize(
+    windowSizeLastState.innerWidth,
+    windowSizeLastState.screenWidth,
+    workArea.width,
+    minWindowWidth
+  )
+  const height = limitWindowSize(
+    windowSizeLastState.height,
+    windowSizeLastState.screenHeight,
+    workArea.height,
+    minWindowHeight
+  )
+
+  return {
+    width,
+    height,
+    x: limitWindowPosition(
+      savedPosition.x,
+      workArea.x,
+      workArea.width,
+      width
+    ),
+    y: limitWindowPosition(
+      savedPosition.y,
+      workArea.y,
+      workArea.height,
+      height
+    )
+  }
+}

--- a/test/unit-ci/window-restore.spec.js
+++ b/test/unit-ci/window-restore.spec.js
@@ -1,0 +1,357 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
+const {
+  restoreWindowBounds
+} = require('../../src/app/lib/window-restore')
+
+const minWindowWidth = 590
+const minWindowHeight = 400
+
+function distanceFromRange (value, start, size) {
+  const end = start + size
+  if (value < start) {
+    return start - value
+  }
+  if (value > end) {
+    return value - end
+  }
+  return 0
+}
+
+function createScreen (displays) {
+  const calls = {
+    matching: [],
+    nearestPoint: []
+  }
+  return {
+    calls,
+    getDisplayMatching (rect) {
+      calls.matching.push(rect)
+      return displays.reduce((best, display) => {
+        const xOverlap = Math.max(0, Math.min(
+          rect.x + rect.width,
+          display.bounds.x + display.bounds.width
+        ) - Math.max(rect.x, display.bounds.x))
+        const yOverlap = Math.max(0, Math.min(
+          rect.y + rect.height,
+          display.bounds.y + display.bounds.height
+        ) - Math.max(rect.y, display.bounds.y))
+        const overlap = xOverlap * yOverlap
+        return !best || overlap > best.overlap
+          ? { display, overlap }
+          : best
+      }, null).display
+    },
+    getDisplayNearestPoint (point) {
+      calls.nearestPoint.push(point)
+      return displays.reduce((best, display) => {
+        const xDistance = distanceFromRange(
+          point.x,
+          display.bounds.x,
+          display.bounds.width
+        )
+        const yDistance = distanceFromRange(
+          point.y,
+          display.bounds.y,
+          display.bounds.height
+        )
+        const distance = Math.hypot(xDistance, yDistance)
+        return !best || distance < best.distance
+          ? { display, distance }
+          : best
+      }, null).display
+    }
+  }
+}
+
+function display ({
+  x,
+  y,
+  width,
+  height,
+  workArea = { x, y, width, height },
+  scaleFactor = 1
+}) {
+  return {
+    bounds: { x, y, width, height },
+    workArea,
+    scaleFactor
+  }
+}
+
+function savedSize ({
+  width = 1000,
+  height = 700,
+  screenWidth,
+  screenHeight
+}) {
+  return {
+    innerWidth: width,
+    height,
+    screenWidth,
+    screenHeight
+  }
+}
+
+function restore ({
+  displays,
+  windowSizeLastState,
+  windowPosLastState,
+  isDev = false
+}) {
+  const screen = createScreen(displays)
+  const bounds = restoreWindowBounds({
+    screen,
+    windowSizeLastState,
+    windowPosLastState,
+    isDev,
+    minWindowWidth,
+    minWindowHeight
+  })
+  return { bounds, screen }
+}
+
+describe('window bounds restoration', () => {
+  it('uses the matching display work area on first launch', () => {
+    const primary = display({
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1080,
+      workArea: { x: 0, y: 0, width: 1920, height: 1040 }
+    })
+    const { bounds, screen } = restore({
+      displays: [primary]
+    })
+
+    assert.deepEqual(bounds, {
+      width: 1920,
+      height: 1040,
+      x: 0,
+      y: 0
+    })
+    assert.equal(screen.calls.matching.length, 1)
+    assert.equal(screen.calls.nearestPoint.length, 0)
+  })
+
+  it('restores a window on the second display', () => {
+    const displays = [
+      display({ x: 0, y: 0, width: 1920, height: 1080 }),
+      display({ x: 1920, y: 0, width: 1920, height: 1080 })
+    ]
+    const { bounds, screen } = restore({
+      displays,
+      windowSizeLastState: savedSize({
+        screenWidth: 1920,
+        screenHeight: 1080
+      }),
+      windowPosLastState: { x: 2100, y: 120 }
+    })
+
+    assert.deepEqual(bounds, {
+      width: 1000,
+      height: 700,
+      x: 2100,
+      y: 120
+    })
+    assert.deepEqual(screen.calls.nearestPoint, [{ x: 2100, y: 120 }])
+  })
+
+  it('uses the second display resolution when restoring its size', () => {
+    const displays = [
+      display({ x: 0, y: 0, width: 2560, height: 1440 }),
+      display({
+        x: 2560,
+        y: 240,
+        width: 1280,
+        height: 1024,
+        workArea: { x: 2560, y: 240, width: 1280, height: 984 }
+      })
+    ]
+    const { bounds } = restore({
+      displays,
+      windowSizeLastState: savedSize({
+        width: 1000,
+        height: 700,
+        screenWidth: 1280,
+        screenHeight: 984
+      }),
+      windowPosLastState: { x: 2700, y: 300 }
+    })
+
+    assert.deepEqual(bounds, {
+      width: 1000,
+      height: 700,
+      x: 2700,
+      y: 300
+    })
+  })
+
+  it('uses work area coordinates reported for a differently scaled display', () => {
+    const displays = [
+      display({
+        x: 0,
+        y: 0,
+        width: 2048,
+        height: 1280,
+        scaleFactor: 1
+      }),
+      display({
+        x: 2048,
+        y: 416,
+        width: 1536,
+        height: 864,
+        scaleFactor: 1.25
+      })
+    ]
+    const { bounds } = restore({
+      displays,
+      windowSizeLastState: savedSize({
+        width: 1494,
+        height: 864,
+        screenWidth: 1536,
+        screenHeight: 864
+      }),
+      windowPosLastState: { x: 2090, y: 416 }
+    })
+
+    assert.deepEqual(bounds, {
+      width: 1494,
+      height: 864,
+      x: 2090,
+      y: 416
+    })
+  })
+
+  it('preserves negative x coordinates for a display left of the primary', () => {
+    const displays = [
+      display({ x: -1920, y: 0, width: 1920, height: 1080 }),
+      display({ x: 0, y: 0, width: 2560, height: 1440 })
+    ]
+    const { bounds } = restore({
+      displays,
+      windowSizeLastState: savedSize({
+        screenWidth: 1920,
+        screenHeight: 1080
+      }),
+      windowPosLastState: { x: -1600, y: 120 }
+    })
+
+    assert.deepEqual(bounds, {
+      width: 1000,
+      height: 700,
+      x: -1600,
+      y: 120
+    })
+  })
+
+  it('preserves negative y coordinates for a display above the primary', () => {
+    const displays = [
+      display({ x: 0, y: -1080, width: 1920, height: 1080 }),
+      display({ x: 0, y: 0, width: 1920, height: 1080 })
+    ]
+    const { bounds } = restore({
+      displays,
+      windowSizeLastState: savedSize({
+        screenWidth: 1920,
+        screenHeight: 1080
+      }),
+      windowPosLastState: { x: 200, y: -900 }
+    })
+
+    assert.deepEqual(bounds, {
+      width: 1000,
+      height: 700,
+      x: 200,
+      y: -900
+    })
+  })
+
+  it('brings a window back with 100 pixels visible after display removal', () => {
+    const primary = display({ x: 0, y: 0, width: 1920, height: 1080 })
+    const { bounds } = restore({
+      displays: [primary],
+      windowSizeLastState: savedSize({
+        screenWidth: 1920,
+        screenHeight: 1080
+      }),
+      windowPosLastState: { x: 2500, y: 1400 }
+    })
+
+    assert.deepEqual(bounds, {
+      width: 1000,
+      height: 700,
+      x: 1820,
+      y: 980
+    })
+  })
+
+  it('does not shrink a nearly full-screen normal window by 200 pixels', () => {
+    const primary = display({ x: 0, y: 0, width: 1536, height: 864 })
+    const { bounds } = restore({
+      displays: [primary],
+      windowSizeLastState: savedSize({
+        width: 1494,
+        height: 864,
+        screenWidth: 1536,
+        screenHeight: 864
+      }),
+      windowPosLastState: { x: 20, y: 0 }
+    })
+
+    assert.deepEqual(bounds, {
+      width: 1494,
+      height: 864,
+      x: 20,
+      y: 0
+    })
+  })
+
+  it('raises saved sizes below the configured minimums', () => {
+    const primary = display({ x: 0, y: 0, width: 1920, height: 1080 })
+    const { bounds } = restore({
+      displays: [primary],
+      windowSizeLastState: savedSize({
+        width: 200,
+        height: 100,
+        screenWidth: 1920,
+        screenHeight: 1080
+      }),
+      windowPosLastState: { x: 50, y: 50 }
+    })
+
+    assert.deepEqual(bounds, {
+      width: minWindowWidth,
+      height: minWindowHeight,
+      x: 50,
+      y: 50
+    })
+  })
+
+  it('limits an oversized saved window to the target work area', () => {
+    const primary = display({
+      x: 100,
+      y: 50,
+      width: 1600,
+      height: 1000,
+      workArea: { x: 100, y: 80, width: 1600, height: 920 }
+    })
+    const { bounds } = restore({
+      displays: [primary],
+      windowSizeLastState: savedSize({
+        width: 2200,
+        height: 1400,
+        screenWidth: 1600,
+        screenHeight: 920
+      }),
+      windowPosLastState: { x: 100, y: 80 }
+    })
+
+    assert.deepEqual(bounds, {
+      width: 1600,
+      height: 920,
+      x: 100,
+      y: 80
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Restore saved normal-window bounds on the correct display in multi-monitor layouts.
- Support displays with different work areas and scale factors, including layouts with negative coordinates.
- Keep a window reachable when its previous display has been disconnected.
- Preserve near-full-screen window sizes without the Linux-only 200-pixel reduction.

## Root cause

Before the BrowserWindow exists, getScreenCurrent falls back to a rectangle at the origin. The selected display was then used to validate both saved global desktop coordinates and saved size ratios. As a result, valid coordinates on another display, including negative coordinates for displays left of or above the primary display, were reset against the wrong single-display bounds. A separate Linux workaround also reduced any near-full-screen window by 200 pixels and moved it to 100,100.

## Changes

- Select the target display from the saved window position with screen.getDisplayNearestPoint.
- Restore the saved size proportionally against the target display workArea, constrained by the configured minimum size and work-area maximum.
- Clamp restored positions against the target work area while keeping at least 100 pixels visible.
- Preserve valid negative coordinates and safely recover windows from disconnected displays.
- Remove the unconditional Linux near-full-screen shrink behavior.
- Add isolated screen/state simulation tests for first launch, secondary displays, mixed resolution and scaling, negative coordinates, display removal, near-full-screen bounds, minimum sizes, and oversized windows.
- Keep the existing windowPos and windowSize persistence formats unchanged.

## Test plan

- [x] npm run lint
- [x] npm run test-unit-ci (64 tests passed, including all 10 window restoration scenarios)
- [x] npm run build