### PR TITLE
Fix terminal black screen on WebGL context loss

### DIFF
--- a/src/client/components/terminal/terminal.jsx
+++ b/src/client/components/terminal/terminal.jsx
@@ -185,6 +185,8 @@ class Term extends Component {
     this.fitAddon = null
     this.cmdAddon = null
     this.imageAddon = null
+    this.webglAddon = null
+    this.webglRecovering = false
   }
 
   terminalConfigProps = [
@@ -1127,13 +1129,50 @@ class Term extends Component {
     if (config.rendererType === rendererTypes.webGL) {
       try {
         const WebglAddon = await loadWebglAddon()
-        term.loadAddon(new WebglAddon())
+        const webglAddon = new WebglAddon()
+        // On macOS native fullscreen the GPU/WebGL context can be lost when
+        // the window migrates across Spaces. Without a listener xterm keeps
+        // drawing into a dead context and every terminal goes black while the
+        // rest of the UI stays alive. Rebuild the addon to recover.
+        webglAddon.onContextLoss(() => {
+          this.handleWebglContextLoss(webglAddon)
+        })
+        term.loadAddon(webglAddon)
+        this.webglAddon = webglAddon
       } catch (e) {
         console.error('render with webgl failed, fallback to dom renderer')
         console.error(e)
         // built-in DOM renderer is used (no addon loaded)
       }
     }
+  }
+
+  handleWebglContextLoss = (webglAddon) => {
+    if (this.webglRecovering) {
+      return
+    }
+    this.webglRecovering = true
+    console.warn('webgl context lost, rebuilding webgl renderer')
+    try {
+      webglAddon.dispose()
+    } catch (e) {
+      console.error(e)
+    }
+    this.webglAddon = null
+    const term = this.term
+    const config = this.props.config
+    Promise.resolve()
+      .then(() => this.loadRenderer(term, config))
+      .then(() => {
+        // Repaint with the buffer content so recovered terminals are not blank.
+        term.refresh(0, term.rows - 1)
+      })
+      .catch(e => {
+        console.error('rebuild webgl renderer failed', e)
+      })
+      .finally(() => {
+        this.webglRecovering = false
+      })
   }
 
   terminalColorQueryDisposables = []


### PR DESCRIPTION
### 问题
在 macOS 上将终端切换到原生全屏后、再切到另一个 Space（四指横扫 / Ctrl+左右）切回来，偶发终端画面变黑且不再重绘，输入无反应；而窗口其余 UI（标签栏、侧栏、菜单）仍正常响应。多个终端会同时黑屏。

### 原因
xterm 的 WebGL addon 在 context 丢失后并不会自动重建渲染上下文。当 macOS 原生全屏窗口跨 Space 迁移时，GPU/WebGL context 被系统回收，触发 webglcontextlost，但 addon 内部仅尝试在 3 秒内恢复，恢复失败后继续向已失效的 context 绘制，导致每个终端持续黑屏，而渲染层以外的 UI 不受影响、依然存活。

### 修复
在 loadRenderer 中为 WebGL addon 注册 onContextLoss 回调，触发时销毁失效的 addon 并重新构建渲染器（loadRenderer + term.refresh 重绘缓冲区内容），用 webglRecovering 标志防止重入。此前该事件无人处理，xterm 一直向死 context 绘制。

### 验证
在 electerm 渲染器设为 WebGL 时，通过 DevTools 对当前活动终端的 webgl canvas 调用 WEBGL_lose_context 扩展的 loseContext() 强制丢失 context（不恢复），3 秒后控制台出现 webgl context lost, rebuilding webgl renderer，终端短暂黑屏后自动重绘恢复正常且输入可用；未修复版本此时终端持续黑屏、输入无反应，需重启应用。