### PR TITLE
fix: validate dispatched method names in dispatch-center and fs

### DIFF
--- a/src/app/server/dispatch-center.js
+++ b/src/app/server/dispatch-center.js
@@ -6,6 +6,7 @@
 const fs = require('./fs')
 const log = require('../common/log')
 const { Upgrade } = require('./download-upgrade')
+const { transferKeys } = require('./transfer')
 const fetch = require('./fetch')
 const sync = require('./sync')
 const {
@@ -59,7 +60,15 @@ const initWs = function (app) {
         await inst.init()
       } else if (action === 'upgrade-func') {
         const { id, func, args } = msg
-        globalState.getUpgradeInst(id)[func](...args)
+        const inst = globalState.getUpgradeInst(id)
+        if (!inst) {
+          return
+        }
+        if (!transferKeys.includes(func) || typeof inst[func] !== 'function') {
+          log.error('invalid upgrade function:', func)
+          return
+        }
+        inst[func](...args)
       }
     })
   })

--- a/src/app/server/fs.js
+++ b/src/app/server/fs.js
@@ -6,6 +6,17 @@ const { fsExport: fs } = require('../lib/fs')
 
 function handleFs (ws, msg) {
   const { id, args, func } = msg
+  // only dispatch to fs helpers defined on the export itself, never to
+  // anything reached through the prototype chain
+  if (!Object.prototype.hasOwnProperty.call(fs, func) || typeof fs[func] !== 'function') {
+    return ws.s({
+      id,
+      error: {
+        message: 'invalid fs function: ' + func,
+        stack: ''
+      }
+    })
+  }
   fs[func](...args)
     .then(data => {
       ws.s({


### PR DESCRIPTION
Follows on from #4438, which added method-name validation to the `sftp-func` and `transfer-func` handlers in `session-server.js`. Two other dispatch sites take a `func` name from the websocket message and invoke it on an internal object without the same check.

`dispatch-center.js`, the `upgrade-func` handler:

```js
const { id, func, args } = msg
globalState.getUpgradeInst(id)[func](...args)
```

`fs.js`, `handleFs`:

```js
const { id, args, func } = msg
fs[func](...args)
```

In both cases any name resolves, including members inherited from the prototype chain, and an unknown name throws synchronously rather than returning an error to the caller.

This applies the same shape as #4438:

- `upgrade-func` allows only `transferKeys` (`pause`, `resume`, `destroy`), which is what `src/client/common/upgrade.js` already limits itself to. It also returns early if no instance is registered for that id, which was an unguarded deref before.
- `handleFs` dispatches only to own properties of the fs export. I used `hasOwnProperty` rather than a literal list because `fsExport` is `Object.assign({}, fs/promises, {...})`, so a hand-written list would need every `fs/promises` method in it and would drift as that surface changes. Own-property matches the intended surface exactly. Unknown names now get an error response instead of throwing.

Checked: `standard` is clean on both files, and I confirmed that `constructor`, `toString`, `hasOwnProperty`, `__defineGetter__` and `__proto__` no longer resolve, while `readFile`, `stat`, `openFile` and `run` still dispatch normally and `pause`/`resume`/`destroy` still work on the upgrade instance.
