### PR TITLE
fix: restore Alt/Option+arrow word-move behavior lost in xterm 6.x

### DIFF
--- a/src/client/components/shortcuts/shortcut-handler.js
+++ b/src/client/components/shortcuts/shortcut-handler.js
@@ -214,6 +214,26 @@ export function shortcutExtend (Cls) {
       this.term.buffer.active.type === 'alternate'
     ) {
       return true
+    } else if (
+      (key === 'ArrowLeft' || key === 'ArrowRight') &&
+      type === 'keydown' &&
+      altKey &&
+      !ctrlKey &&
+      !shiftKey &&
+      !metaKey
+    ) {
+      // Restore xterm 5.5.0 behavior: convert Alt/Option + Left/Right into
+      // readline-compatible word-movement sequences.
+      // xterm 6.x dropped the platform-specific override in evaluateKeyboardEvent,
+      // which now sends CSI modifier sequences (e.g. ESC[1;3D) that old shells
+      // do not bind to backward-word / forward-word, causing trailing chars
+      // ("D", ";3D") to leak as literal input.
+      const seq = key === 'ArrowLeft'
+        ? (isMacJs ? '\x1bb' : '\x1b[1;5D')
+        : (isMacJs ? '\x1bf' : '\x1b[1;5C')
+      sendInputData(this, seq)
+      this.term?.scrollToBottom()
+      return false
     }
 
     if (


### PR DESCRIPTION
### 问题
1. electerm v3.15.95+（xterm 5.5.0 → 6.1.0），Option+←/→ 无法按词移动光标，在 CentOS 7 等老 readline 环境中漏出字面字符 "D"（或 ";3D"）；Windows/Linux 的 Alt+←/→ 同样失效。
2. 该问题影响了所有远程老系统（CentOS 7 / bash 4.2 / readline 6.2）以及部分默认 inputrc 未绑定 CSI modifier 序列的本地 shell，表现为按 Option+← 在命令行插入乱码而非跳词。

### 原因
1. xterm 5.5.0 的 evaluateKeyboardEvent 内部有平台特判：macOS 上 Option+←/→ 被改写为 ESC b / ESC f（readline 默认的 backward-word/forward-word 按键），Windows 上 Alt+←/→ 被改写为 ESC[1;5D / ESC[1;5C（Ctrl+←/→ 的标准序列）。xterm 6.x 将这段特判整体移除，Option/Alt+←/→ 现在统一发 CSI modifier 序列 ESC[1;3D/ESC[1;3C（modifier=3 即 Alt），而老 readline 默认 inputrc 并未绑定此序列，readline 解析失败后将序列的尾部字面字符 "D" / ";3D" 误当作普通输入插入命令行。
2. electerm 的快捷键处理器 handleKeyboardEvent 对 Option/Alt+←/→ 返回 true 将事件透传给 xterm 处理，但 xterm 6.x 已不再输出与 readline 兼容的序列，且 macOptionIsMeta 选项在 electerm 中从未被设置为 true。

### 验证
在 macOS arm64 上本地构建，测试以下场景均恢复正常：
- macOS 本地终端（zsh/bash）：Option+←/→ 按词移动光标，不再出现 ";3D" 乱码
- SSH 到 CentOS 7（bash 4.2 / readline 6.2）：Option+←/→ 按词
- Windows/Linux（Cross-platform 逻辑已包含）：Alt+←/→ 发 ESC[1;5D/ESC[1;5C，匹配老 readline 默认绑定
- vim / less 等 alternate buffer：不受影响，Option/Alt+←/→ 保持原样