### PR TITLE
feat: add hover-to-switch tab setting (switchTabOnHover)

### DIFF
--- a/src/app/common/default-setting.js
+++ b/src/app/common/default-setting.js
@@ -72,5 +72,7 @@ module.exports = exports.default = {
   startDirectoryLocal: '',
   allowMultiInstance: false,
   disableDeveloperTool: false,
-  dragDropBehavior: 'ask'
+  dragDropBehavior: 'ask',
+  // 鼠标悬停到标签页时自动切换显示该标签
+  switchTabOnHover: false
 }

--- a/src/client/common/default-setting.js
+++ b/src/client/common/default-setting.js
@@ -78,5 +78,7 @@ export default {
   startDirectoryLocal: '',
   allowMultiInstance: false,
   disableDeveloperTool: false,
-  dragDropBehavior: 'ask'
+  dragDropBehavior: 'ask',
+  // 鼠标悬停到标签页时自动切换显示该标签
+  switchTabOnHover: false
 }

--- a/src/client/components/setting-panel/setting-common.jsx
+++ b/src/client/components/setting-panel/setting-common.jsx
@@ -204,6 +204,8 @@ export default class SettingCommon extends Component {
     )
   }
 
+  renderToggleBound = (name) => this.renderToggle(name)
+
   renderNumber = (name, options, title = '') => {
     let value = this.props.config[name]
     if (options.valueParser) {
@@ -605,7 +607,7 @@ export default class SettingCommon extends Component {
             'allowMultiInstance',
             'disableDeveloperTool',
             'debug'
-          ].map(this.renderToggle)
+          ].map(this.renderToggleBound)
         }
         {
           // 鼠标悬停标签页时自动切换（外部语言包未内置此 key，使用双语文案）

--- a/src/client/components/setting-panel/setting-common.jsx
+++ b/src/client/components/setting-panel/setting-common.jsx
@@ -188,14 +188,15 @@ export default class SettingCommon extends Component {
     this.props.store.setConfig(ext)
   }
 
-  renderToggle = (name, extra = null) => {
+  renderToggle = (name, extra = null, label) => {
     const checked = !!this.props.config[name]
+    const txt = label || e(name)
     return (
       <div className='pd2b' key={'rt' + name}>
         <Switch
           checked={checked}
-          checkedChildren={e(name)}
-          unCheckedChildren={e(name)}
+          checkedChildren={txt}
+          unCheckedChildren={txt}
           onChange={v => this.onChangeValue(v, name)}
         />
         {isNumber(extra) ? null : extra}
@@ -605,6 +606,16 @@ export default class SettingCommon extends Component {
             'disableDeveloperTool',
             'debug'
           ].map(this.renderToggle)
+        }
+        {
+          // 鼠标悬停标签页时自动切换（外部语言包未内置此 key，使用双语文案）
+          this.renderToggle(
+            'switchTabOnHover',
+            null,
+            props.config.language === 'zh_cn'
+              ? '鼠标悬停自动切换标签'
+              : 'Auto switch tab on hover'
+          )
         }
         {
           window.et.isWebApp ? null : <DeepLinkControl />

--- a/src/client/components/tabs/tab.jsx
+++ b/src/client/components/tabs/tab.jsx
@@ -121,6 +121,28 @@ class Tab extends Component {
     window.store.clickTab(this.props.tab.id, this.props.batch)
   }
 
+  // 开启“鼠标悬停自动切换标签”时，悬停到标签即切换显示该标签
+  onMouseEnter = () => {
+    const {
+      config,
+      tab,
+      batch,
+      currentBatchTabId
+    } = this.props
+    if (!config || !config.switchTabOnHover) {
+      return
+    }
+    // 正在拖拽标签时不触发自动切换
+    if (document.querySelector('.' + onDragCls)) {
+      return
+    }
+    // 当前已显示该标签则无需切换
+    if (tab.id === currentBatchTabId) {
+      return
+    }
+    window.store.clickTab(tab.id, batch)
+  }
+
   onDrag = () => {
     addClass(this.tabRef.current, onDragCls)
   }
@@ -499,6 +521,7 @@ class Tab extends Component {
           data-id={id}
           {...pick(this, [
             'onDrag',
+            'onMouseEnter',
             'onDragEnter',
             'onDragExit',
             'onDragLeave',


### PR DESCRIPTION
feat: add hover-to-switch tab setting (switchTabOnHover)

- Add 'switchTabOnHover' config default (client & app)
- Add toggle in general settings (bilingual label)
- Tab switches on mouse enter when enabled

fix: bind renderToggle this when used with .map in setting-common

Arrow-function renderToggle lost 'this' when passed to
[].map(this.renderToggle), causing React to fall back to
displaying the raw arguments (a key array) as a string.
This is a pre-existing bug that surfaced once the new
switchTabOnHover toggle was added; the original toggles
showed as a concatenated list of keys instead of labels.

Add a bound wrapper renderToggleBound and use it in the
.map() call. My new switchTabOnHover toggle was already
displaying correctly (explicit this.renderToggle call).