### PR TITLE
fix: 修复终端选中背景半透明不生效与选中文本背景不透明问题

### DIFF
--- a/src/client/components/terminal/terminal-color-query.mjs
+++ b/src/client/components/terminal/terminal-color-query.mjs
@@ -104,6 +104,53 @@ export function colorToOscRgb (color) {
   return `rgb:${rgb.map(toHexByte).join('/')}`
 }
 
+/**
+ * Blend a (possibly translucent) selection color over an opaque background,
+ * producing the colour in xterm's internal format ({ css, rgba } where
+ * rgba = r<<24 | g<<16 | b<<8 | a).
+ *
+ * xterm derives its DOM selection colour as blend(theme.background,
+ * selectionBackground). When the terminal background is forced transparent
+ * (DOM renderer keeps the real background behind via CSS), that blend runs
+ * over transparent-black and a light selection turns into dark gray. This
+ * helper recomputes it over the real visible background instead.
+ *
+ * `selectionColor` is an xterm color object ({ css, rgba }) e.g.
+ * colors.selectionBackgroundTransparent; `visibleBackground` is an opaque
+ * colour string.
+ */
+export function blendSelectionOverBackground (visibleBackground, selectionColor) {
+  const bgRgb = parseColorToRgb(visibleBackground)
+  const sel = selectionColor?.rgba
+  if (!bgRgb || typeof sel !== 'number') {
+    return null
+  }
+  const [br, bg, bb] = bgRgb
+  const a = (sel & 255) / 255
+  if (a <= 0) {
+    return null
+  }
+  const toCss = (r, g, b, alpha) =>
+    `#${[r, g, b, alpha].map(toHexByte).join('')}`
+  const sr = sel >> 24 & 255
+  const sg = sel >> 16 & 255
+  const sb = sel >> 8 & 255
+  if (a >= 1) {
+    return {
+      css: toCss(sr, sg, sb, 255),
+      rgba: ((sel & 0xffffff) | 0xff000000) >>> 0
+    }
+  }
+  const r = br + Math.round((sr - br) * a)
+  const g = bg + Math.round((sg - bg) * a)
+  const b = bb + Math.round((sb - bb) * a)
+  const alpha = Math.round(a * 255)
+  return {
+    css: toCss(r, g, b, alpha),
+    rgba: (r << 24 | g << 16 | b << 8 | alpha) >>> 0
+  }
+}
+
 export function buildOscColorResponse (identifier, color, fallbackColor) {
   const oscColor = colorToOscRgb(color) || colorToOscRgb(fallbackColor)
   return oscColor

--- a/src/client/components/terminal/terminal.jsx
+++ b/src/client/components/terminal/terminal.jsx
@@ -71,7 +71,8 @@ import {
 } from './xterm-loader.js'
 import {
   createRendererThemeConfig,
-  handleTerminalColorQuery
+  handleTerminalColorQuery,
+  blendSelectionOverBackground
 } from './terminal-color-query.mjs'
 
 const e = window.translate
@@ -1456,6 +1457,7 @@ class Term extends Component {
       return
     }
     term.options.theme = this.getRendererThemeConfig(this.props.themeConfig)
+    this.fixSelectionColors(term)
     term.refresh(0, term.rows - 1)
     if (deferred && this.props.config.rendererType === rendererTypes.webGL) {
       window.cancelAnimationFrame(this.timers.themeRaf)
@@ -1464,9 +1466,44 @@ class Term extends Component {
           return
         }
         this.term.options.theme = this.getRendererThemeConfig(this.props.themeConfig)
+        this.fixSelectionColors(this.term)
         this.term.refresh(0, this.term.rows - 1)
       })
     }
+  }
+
+  /**
+   * xterm computes its DOM selection colour as blend(theme.background,
+   * selectionBackground). The DOM renderer keeps the terminal background
+   * transparent (rgba(0,0,0,0)) so electerm's own CSS background / image
+   * shows through, which makes a light selection blend over transparent-black
+   * and render as dark gray. Recompute the selection over the real visible
+   * background so terminal:selectionBackground=rgba(...) is applied as the
+   * configured semi-transparent colour.
+   */
+  fixSelectionColors = (term) => {
+    const themeService = term?._core?._themeService
+    if (!themeService?.modifyColors) {
+      return
+    }
+    const visibleBackground = this.getVisibleTerminalBackground()
+    const colors = themeService.colors
+    themeService.modifyColors((c) => {
+      const active = blendSelectionOverBackground(
+        visibleBackground,
+        colors.selectionBackgroundTransparent
+      )
+      if (active) {
+        c.selectionBackgroundOpaque = active
+      }
+      const inactive = blendSelectionOverBackground(
+        visibleBackground,
+        colors.selectionInactiveBackgroundTransparent
+      )
+      if (inactive) {
+        c.selectionInactiveBackgroundOpaque = inactive
+      }
+    })
   }
 
   initTerminal = async () => {
@@ -1492,6 +1529,7 @@ class Term extends Component {
     term.open(this.domRef.current, true)
     this.registerTerminalColorQueryHandlers(term, themeConfig)
     await this.loadRenderer(term, config)
+    this.fixSelectionColors(term)
     // Re-apply the theme after the renderer is loaded. The Terminal was
     // constructed before UiTheme's useEffect ran, so the initial theme
     // may have a stale background. Pass `term` directly because this.term

--- a/src/client/components/terminal/terminal.styl
+++ b/src/client/components/terminal/terminal.styl
@@ -34,6 +34,16 @@
     background transparent
   .xterm-viewport
     background-color transparent !important
+  // xterm's DOM renderer paints the background of *selected* cells directly on
+  // the text <span> as an opaque 6-digit hex (dropping the alpha channel),
+  // while empty cells use the translucent .xterm-selection overlay. To keep the
+  // selection highlight uniformly semi-transparent over text too, neutralise
+  // that opaque inline background when a selection overlay is present so the
+  // overlay renders the highlight consistently.
+  .xterm:has(.xterm-selection div)
+    .xterm-rows
+      span[style*='background-color']
+        background-color transparent !important
   .xterm-screen::before
     content ''
     position absolute

--- a/test/unit-ci/terminal-color-query.spec.js
+++ b/test/unit-ci/terminal-color-query.spec.js
@@ -62,4 +62,25 @@ describe('terminal OSC color query helpers', () => {
       }
     )
   })
+
+  test('blends a translucent selection over the real visible background', async () => {
+    const { blendSelectionOverBackground } = await import('../../src/client/components/terminal/terminal-color-query.mjs')
+    const color = (r, g, b, a) => ({ css: '', rgba: (r << 24 | g << 16 | b << 8 | a) >>> 0 })
+
+    // white rgba(255,255,255,0.3) over #20111b -> light semi-transparent highlight
+    assert.equal(
+      blendSelectionOverBackground('#20111b', color(255, 255, 255, 76))?.css,
+      '#62585f4c'
+    )
+
+    // an opaque selection stays opaque
+    assert.equal(
+      blendSelectionOverBackground('#20111b', color(0x57, 0x52, 0x56, 255))?.css,
+      '#575256ff'
+    )
+
+    // invalid background / fully transparent selection yield null
+    assert.equal(blendSelectionOverBackground('nope', color(255, 255, 255, 76)), null)
+    assert.equal(blendSelectionOverBackground('#20111b', color(255, 255, 255, 0)), null)
+  })
 })


### PR DESCRIPTION
## 背景

当主题设置 \	erminal:selectionBackground=rgba(255, 255, 255, 0.3)\ 时，选中文本的背景色无法呈现为半透明浅色，而显示为深灰或完全不生效。

## 根因

1. **选中颜色变深灰**：xterm 用 \lend(theme.background, selectionBackground)\ 计算 DOM 渲染器的选中色。而 electerm 为了让终端背景图/自绘背景透出，把 DOM 渲染器的主题背景强制为 \gba(0,0,0,0)\，导致浅色选中在透明黑上被预乘成深灰。
2. **选中文本 span 背景不透明**：xterm DOM 渲染器会把选中单元格的文本 \<span>\ 直接写成 6 位 hex 的内联 \ackground-color\（丢弃 alpha、不透明），而空白区用的是半透明覆盖层，导致选中时文本处与空白处不一致。

## 改动

- \	erminal-color-query.mjs\：新增 \lendSelectionOverBackground()\，把（可能带 alpha 的）选中色在真实可见背景上混合，产出 xterm 内部格式颜色。
- \	erminal.jsx\：新增 \ixSelectionColors()\，在主题应用后通过 \modifyColors()\ 把 \selectionBackgroundOpaque\ / \selectionInactiveBackgroundOpaque\ 重算为在真实可见背景上混合的结果，并触发渲染器重注入 CSS。
- \	erminal.styl\：加 \:has(.xterm-selection div)\ 限定规则，把选中的 span 内联不透明背景覆盖为透明，统一由半透明覆盖层渲染（仅在选中期间生效）。
- \	est/unit-ci/terminal-color-query.spec.js\：补充混合函数的单元测试。

## 验证

- \
ode --test test/unit-ci/terminal-color-query.spec.js\：5 项全部通过。
- 本地运行验证：背景图正常显示；选中文本处与空白处一致，均为半透明高亮。