### PR TITLE
fix: 修复 Windows 下全屏 TUI 退出导致终端标签页卡死与乱码

### DIFF
--- a/build/electron-builder.json
+++ b/build/electron-builder.json
@@ -9,6 +9,9 @@
     "en-US"
   ],
   "asar": true,
+  "asarUnpack": [
+    "node_modules/node-pty/build/Release/**"
+  ],
   "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
   "win": {
     "target": [

--- a/src/app/server/session-local.js
+++ b/src/app/server/session-local.js
@@ -50,7 +50,14 @@ class TerminalLocal extends TerminalBase {
       cols: cols || 80,
       rows: rows || 24,
       cwd,
-      env
+      env,
+      // Use the OpenConsole conpty.dll shipped with node-pty instead of the
+      // legacy Windows Console Host (kernel32 CreatePseudoConsole) conpty.
+      // The legacy console-host conpty can stall output and deliver Ctrl+C to
+      // the whole process group (killing the shell too) after a full-screen
+      // TUI like opencode exits, leaving the terminal tab unresponsive.
+      // The OpenConsole conpty.dll does not have this problem.
+      useConptyDll: true
     })
     this.term.termType = termType
     globalState.setSession(this.pid, this)


### PR DESCRIPTION
## 背景

Windows 下，在 electerm 本地终端运行全屏 TUI 程序（如 opencode）并用 Ctrl+C 退出后，终端标签页会卡死/乱码（无回显、无输出，看似整个标签页无响应）。

## 根因

electerm 通过 node-pty 使用 **Windows 控制台主机（kernel32 \CreatePseudoConsole\）的旧 conpty**。该实现在全屏 TUI 退出后：
- 把 Ctrl+C 传播到**整个控制台进程组（连同 shell）**，导致 shell 退出、终端无响应；
- 或 conout 输出管道停住，渲染器一直响应但收不到任何数据。

用 headless 复现：opencode 用 Ctrl+C 退出后，node-pty 报 \Cannot resize a pty that has already exited\（shell 被杀），连续运行多次必现。

## 改动

- \src/app/server/session-local.js\：node-pty spawn 加 \useConptyDll: true\，改用 node-pty 自带的 **OpenConsole conpty.dll**（Windows Terminal 同源），该实现无此问题。
- \uild/electron-builder.json\：加 \sarUnpack\ 解包 node-pty 原生目录，保证打包后 conpty.dll 可被 \LoadLibraryW\ 加载。

## 兼容性

- Win10 1809+ / Win11：使用 OpenConsole conpty.dll，修复卡死/乱码。
- Win7 / Win10 < 1809（无 ConPTY）：node-pty 自动回退 winpty（\useConpty\ 未强制，按 build ≥ 18309 判断），不受影响。

## 验证

- headless（node-pty 直接 spawn powershell）：旧实现下 1~2 次 opencode 运行即卡死；\useConptyDll: true\ 下连续 6 次运行 + Ctrl+C 退出均正常。
- 应用内实测：opencode 排版不再乱码，Ctrl+C 退出后终端正常。