### PR TITLE
feat(ai): add OrcaRouter AI provider preset

### DIFF
--- a/src/client/components/ai/ai-config-props.js
+++ b/src/client/components/ai/ai-config-props.js
@@ -52,6 +52,14 @@ export const defaultAIPresets = [
     authHeaderNameAI: 'Authorization: Bearer'
   },
   {
+    id: 'orcarouter',
+    nameAI: 'OrcaRouter',
+    baseURLAI: 'https://api.orcarouter.ai/v1',
+    apiPathAI: '/chat/completions',
+    modelAI: 'deepseek/deepseek-v4-flash',
+    authHeaderNameAI: 'Authorization: Bearer'
+  },
+  {
     id: 'google',
     nameAI: 'Google Gemini',
     baseURLAI: 'https://generativelanguage.googleapis.com/v1beta/openai',


### PR DESCRIPTION
[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR registers it as a named AI preset so users can opt in directly.

I'm an engineer on the OrcaRouter team.

**Changes**
- `src/client/components/ai/ai-config-props.js` — add an `orcarouter` entry to `defaultAIPresets` (base URL `https://api.orcarouter.ai/v1`, `/chat/completions`, seed model `deepseek/deepseek-v4-flash`), mirroring the existing OpenRouter preset.

**Testing**
- `node --check` on the changed file — clean.
- `standard` lint on the changed file — clean.
- Live check against the OrcaRouter API (`https://api.orcarouter.ai/v1/chat/completions`) with `deepseek/deepseek-v4-flash` returns 200 with a valid completion.
