### PR TITLE
Settings overlay and bookmark editor: layout and spacing pass

### DIFF
--- a/src/app/upgrade/db-defaults.js
+++ b/src/app/upgrade/db-defaults.js
@@ -16,18 +16,18 @@ function parsor (themeTxt) {
 }
 
 const defaultTheme = parsor(`
-  main = #141314
-  main-dark = #000
-  main-light = #2E3338
-  text = #ddd
+  main = #0f1317
+  main-dark = #0c1013
+  main-light = #1f2830
+  text = #dfe6ea
   text-light = #fff
-  text-dark = #888
-  text-disabled = #777
-  primary = #08c
-  info = #FFD166
-  success = #06D6A0
-  error = #EF476F
-  warn = #E55934
+  text-dark = #9aa9b4
+  text-disabled = #6c7b86
+  primary = #0e8fce
+  info = #f0c96a
+  success = #35d0a5
+  error = #f46d85
+  warn = #e8a33d
 `)
 const defaultThemeLight = parsor(`
   main=#ededed

--- a/src/client/common/form-layout.js
+++ b/src/client/common/form-layout.js
@@ -2,26 +2,22 @@
  * form layout
  */
 
+// Labels sit on top, left-aligned, so every field shares one left edge.
+// Full-span label/wrapper is what makes Form layout='vertical' render cleanly;
+// the previous sm:8 / sm:16 split reserved a third of the pane for a
+// right-aligned label channel that was mostly empty.
 export const formItemLayout = {
   labelCol: {
-    xs: { span: 24 },
-    sm: { span: 8 }
+    span: 24
   },
   wrapperCol: {
-    xs: { span: 24 },
-    sm: { span: 16 }
+    span: 24
   }
 }
 
 export const tailFormItemLayout = {
   wrapperCol: {
-    xs: {
-      span: 24,
-      offset: 0
-    },
-    sm: {
-      span: 14,
-      offset: 8
-    }
+    span: 24,
+    offset: 0
   }
 }

--- a/src/client/common/theme-defaults.js
+++ b/src/client/common/theme-defaults.js
@@ -17,18 +17,18 @@ function parsor (themeTxt) {
 
 const defaultThemeDark = () => {
   return parsor(`
-main-dark=#000
-main-light=#2E3338
-text=#ddd
+main-dark=#0c1013
+main-light=#1f2830
+text=#dfe6ea
 text-light=#fff
-text-dark=#888
-text-disabled=#777
-primary=#08c
-info=#FFD166
-success=#06D6A0
-error=#EF476F
-warn=#E55934
-main=#121214
+text-dark=#9aa9b4
+text-disabled=#6c7b86
+primary=#0e8fce
+info=#f0c96a
+success=#35d0a5
+error=#f46d85
+warn=#e8a33d
+main=#0f1317
   `)
 }
 const defaultThemeLightFunc = () => {

--- a/src/client/components/bookmark-form/bookmark-form.styl
+++ b/src/client/components/bookmark-form/bookmark-form.styl
@@ -48,6 +48,10 @@
         flex 1
         min-height 0
         overflow-y auto
+        // Setting only overflow-y makes overflow-x compute to auto, so any
+        // element a few px wider than the pane raises a horizontal scrollbar
+        // across the bottom of the field list. Nothing here scrolls sideways.
+        overflow-x hidden
         padding-bottom 18px
         // The panel hides scrollbars globally, which is exactly why there was
         // no sign that more fields existed below. Put one back, here only.
@@ -108,6 +112,10 @@
 // drop their own labels so the controls share a single line beneath it.
 .bookmark-form-row
   margin-bottom 24px
+  // antd's gutter gives the Row margin -6px on each side, which the Cols'
+  // padding cancels out for the content but not for the Row's own box: it
+  // ends up 12px wider than its container. The gap is empty, so clip it.
+  overflow-x hidden
   .bookmark-form-row-label
     padding-bottom 8px
     color var(--text)

--- a/src/client/components/bookmark-form/bookmark-form.styl
+++ b/src/client/components/bookmark-form/bookmark-form.styl
@@ -19,6 +19,12 @@
   min-height 0
   flex 1
 
+// form-renderer wraps each sub-tab's fields in a pd1x, which inset them 5px
+// further than the header above them and than every other tab's content.
+.bookmark-form-scroll .ant-tabs-content > .pd1x
+  padding-left 0
+  padding-right 0
+
 .bookmark-form-scroll
   position relative
   flex 1

--- a/src/client/components/bookmark-form/bookmark-form.styl
+++ b/src/client/components/bookmark-form/bookmark-form.styl
@@ -1,3 +1,119 @@
+// Detail pane: the field list scrolls, the action buttons stay pinned to the
+// bottom. Previously Save sat at the end of a ~1300px scroll.
+// The detail column has to be an unbroken flex chain from the scroll host down
+// to the form, or the footer has no fixed bottom to pin against. Scoped with
+// :has() so the other setting tabs keep scrolling exactly as before.
+.setting-col-content:has(.bookmark-form-detail)
+  display flex
+  flex-direction column
+  overflow hidden
+  .form-wrap
+    flex 1
+    min-height 0
+    display flex
+    flex-direction column
+
+.bookmark-form-detail
+  display flex
+  flex-direction column
+  min-height 0
+  flex 1
+
+.bookmark-form-scroll
+  position relative
+  flex 1
+  min-height 0
+  overflow-y auto
+  overflow-x hidden
+  // Line length cap: beyond this, scanning a label/value pair gets harder.
+  max-width 760px
+
+  // When the form is tabbed, the tab bar stays put and only the field list
+  // under it scrolls -- so you can switch tab without scrolling back up.
+  &:has(> .ant-tabs)
+    display flex
+    flex-direction column
+    overflow hidden
+    > .ant-tabs
+      flex 1
+      min-height 0
+      display flex
+      flex-direction column
+      > .ant-tabs-nav
+        flex-shrink 0
+        margin-bottom 8px
+      // antd 6 names this body-holder; antd 5 called it content-holder.
+      > .ant-tabs-body-holder
+      > .ant-tabs-content-holder
+        flex 1
+        min-height 0
+        overflow-y auto
+        padding-bottom 18px
+        // The panel hides scrollbars globally, which is exactly why there was
+        // no sign that more fields existed below. Put one back, here only.
+        &::-webkit-scrollbar
+          width 8px
+        &::-webkit-scrollbar-thumb
+          background var(--main-light)
+          border-radius 4px
+        &::-webkit-scrollbar-track
+          background transparent
+
+
+.bookmark-form-foot
+  flex-shrink 0
+  max-width 760px
+  padding-top 12px
+  border-top 1px solid var(--main-light)
+
+// All five actions on one line: save cluster left, connect cluster right.
+.bookmark-form-actions
+  margin-bottom 0
+  .bookmark-form-actions-row
+    display flex
+    align-items center
+    gap 8px
+    flex-wrap wrap
+  // Pushes this button and everything after it to the right edge.
+  .bookmark-form-actions-gap
+    margin-left auto
+
+// A paired row carries ONE label across its full width; the children inside
+// drop their own labels so the controls share a single line beneath it.
+.bookmark-form-row
+  margin-bottom 24px
+  .bookmark-form-row-label
+    padding-bottom 8px
+    color var(--text)
+  .ant-form-item-label
+    display none
+  .ant-form-item
+    margin-bottom 0
+
+// Section heading: a label plus a hairline. No collapsing, no persisted state.
+.bookmark-form-section
+  margin 26px 0 14px
+  padding-bottom 6px
+  border-bottom 1px solid var(--main-light)
+  color var(--text-dark)
+  font-size 12px
+  font-weight 600
+  letter-spacing .05em
+  text-transform uppercase
+  &:first-child
+    margin-top 0
+
+// Below this width the whole settings pane scrolls as one column, so the
+// inner scroller and the fixed height have to stand down.
+@media (max-width: 1100px)
+  .bookmark-form-detail
+    height auto
+  .bookmark-form-scroll
+    overflow visible
+    max-width none
+  .bookmark-form-foot
+    max-width none
+
 .mg24b
   margin-bottom 24px
 .mg60b

--- a/src/client/components/bookmark-form/bookmark-form.styl
+++ b/src/client/components/bookmark-form/bookmark-form.styl
@@ -152,6 +152,24 @@
   .bookmark-form-scroll
     overflow visible
     max-width none
+
+  // Same specificity trap one level down: the pinned-tab block above is also
+  // written with :has(), so it outranks the plain rule here and keeps an inner
+  // scroller alive. With the pane stacked into one column there is nothing to
+  // pin the tab bar against, and the inner scroller is what stopped the sticky
+  // footer from ever reaching its scrollport.
+  .bookmark-form-scroll:has(> .ant-tabs)
+    display block
+    overflow visible
+    > .ant-tabs
+      display block
+      flex none
+      > .ant-tabs-body-holder
+      > .ant-tabs-content-holder
+        flex none
+        min-height auto
+        overflow visible
+        padding-bottom 0
   // The pane scrolls as one column here, so the flex footer cannot pin. Sticky
   // keeps Save reachable without fighting the stacked layout; it needs an
   // opaque background or the fields scroll through it.

--- a/src/client/components/bookmark-form/bookmark-form.styl
+++ b/src/client/components/bookmark-form/bookmark-form.styl
@@ -31,8 +31,6 @@
   min-height 0
   overflow-y auto
   overflow-x hidden
-  // Line length cap: beyond this, scanning a label/value pair gets harder.
-  max-width 760px
 
   // When the form is tabbed, the tab bar stays put and only the field list
   // under it scrolls -- so you can switch tab without scrolling back up.
@@ -48,6 +46,9 @@
       > .ant-tabs-nav
         flex-shrink 0
         margin-bottom 8px
+        // The nav sits outside the scroller, so its underline would run 28px
+        // past the fields and the section hairlines below it.
+        margin-right 28px
       // antd 6 names this body-holder; antd 5 called it content-holder.
       > .ant-tabs-body-holder
       > .ant-tabs-content-holder
@@ -59,6 +60,9 @@
         // across the bottom of the field list. Nothing here scrolls sideways.
         overflow-x hidden
         padding-bottom 18px
+        // Keep the fields off the scrollbar: without this the inputs run
+        // right up against it.
+        padding-right 20px
         // The panel hides scrollbars globally, which is exactly why there was
         // no sign that more fields existed below. Put one back, here only.
         &::-webkit-scrollbar
@@ -72,8 +76,11 @@
 
 .bookmark-form-foot
   flex-shrink 0
-  max-width 760px
   padding-top 12px
+  // The footer sits outside the scroller, so it gets neither the field list's
+  // 20px gutter nor the 8px the scrollbar occupies. Match both, or the
+  // buttons overhang the inputs above them on the right.
+  padding-right 28px
   border-top 1px solid var(--main-light)
 
 // All five actions on one line: save cluster left, connect cluster right.

--- a/src/client/components/bookmark-form/bookmark-form.styl
+++ b/src/client/components/bookmark-form/bookmark-form.styl
@@ -78,6 +78,32 @@
   .bookmark-form-actions-gap
     margin-left auto
 
+// Header row one: title, with the AI alternative sitting quietly next to it.
+// Ghost styling keeps it available without competing with the selected type.
+.form-title
+  display flex
+  align-items center
+  min-width 0
+  // The edited bookmark's name is unbounded user input on a nowrap row, so it
+  // has to be the thing that gives way rather than pushing the row off screen.
+  > b
+    min-width 0
+    overflow hidden
+    white-space nowrap
+    text-overflow ellipsis
+
+.create-ai-btn
+  margin-left 14px
+  font-weight normal
+
+// Header row two: the protocol selector, on its own line so nine buttons are
+// not fighting the title for horizontal room, and with air above it so the
+// two rows read as separate decisions.
+.form-types
+  display flex
+  flex-wrap wrap
+  margin-top 14px
+
 // A paired row carries ONE label across its full width; the children inside
 // drop their own labels so the controls share a single line beneath it.
 .bookmark-form-row
@@ -85,7 +111,9 @@
   .bookmark-form-row-label
     padding-bottom 8px
     color var(--text)
-  .ant-form-item-label
+  // Only children flagged hideLabel drop their label; the rest keep theirs so
+  // a required field keeps its asterisk.
+  .hide-own-label .ant-form-item-label
     display none
   .ant-form-item
     margin-bottom 0
@@ -106,13 +134,34 @@
 // Below this width the whole settings pane scrolls as one column, so the
 // inner scroller and the fixed height have to stand down.
 @media (max-width: 1100px)
+  // The :has() flex chain further up outranks the plain .setting-col-content
+  // rule in setting-wrap.styl, so a media query alone does not undo it. Left
+  // standing it keeps overflow:hidden on a 1890px-tall box, which clips the
+  // pane AND gives the sticky footer a non-scrolling container to stick in.
+  .setting-col-content:has(.bookmark-form-detail)
+    display block
+    overflow visible
+    .form-wrap
+      display block
+      flex none
+      min-height auto
+
   .bookmark-form-detail
+    display block
     height auto
   .bookmark-form-scroll
     overflow visible
     max-width none
+  // The pane scrolls as one column here, so the flex footer cannot pin. Sticky
+  // keeps Save reachable without fighting the stacked layout; it needs an
+  // opaque background or the fields scroll through it.
   .bookmark-form-foot
     max-width none
+    position sticky
+    bottom 0
+    z-index 3
+    background var(--main)
+    padding-bottom 8px
 
 .mg24b
   margin-bottom 24px

--- a/src/client/components/bookmark-form/common/color-picker.jsx
+++ b/src/client/components/bookmark-form/common/color-picker.jsx
@@ -55,7 +55,12 @@ export function ColorPicker ({ value, onChange, ref, disabled, isRgba }) {
   }
 
   const inner = (
-    <div ref={ref} className='color-picker-choose' style={{ backgroundColor: value }} />
+    <div
+      ref={ref}
+      className='color-picker-choose'
+      title={window.translate('color')}
+      style={{ backgroundColor: value }}
+    />
   )
 
   if (disabled) return inner

--- a/src/client/components/bookmark-form/common/color-picker.styl
+++ b/src/client/components/bookmark-form/common/color-picker.styl
@@ -13,7 +13,16 @@
 
 .color-picker-defaults
   width 200px
+// Without a border this is a bare coloured rectangle sitting inside a text
+// input, which reads as a rendering artifact rather than a control. The border
+// and radius give it an edge, and it stays visible when no colour is set.
 .color-picker-choose
   width 18px
   height 18px
   cursor pointer
+  border-radius 3px
+  border 1px solid var(--main-light)
+  box-sizing border-box
+  flex-shrink 0
+  &:hover
+    border-color var(--primary)

--- a/src/client/components/bookmark-form/common/fields.jsx
+++ b/src/client/components/bookmark-form/common/fields.jsx
@@ -136,7 +136,11 @@ export function renderFormItem (item, formItemLayout, form, ctxProps, index) {
           <Row gutter={12} align='bottom'>
             {
               (item.children || []).map((child, i) => (
-                <Col key={child.name || i} span={child.span || 12}>
+                <Col
+                  key={child.name || i}
+                  span={child.span || 12}
+                  className={child.hideLabel ? 'hide-own-label' : undefined}
+                >
                   {renderFormItem(child, formItemLayout, form, ctxProps, i)}
                 </Col>
               ))

--- a/src/client/components/bookmark-form/common/fields.jsx
+++ b/src/client/components/bookmark-form/common/fields.jsx
@@ -3,7 +3,7 @@
  * Maps field types to React components
  */
 import React from 'react'
-import { Form, Input, InputNumber, Select, AutoComplete, Alert, Radio } from 'antd'
+import { Form, Input, InputNumber, Select, AutoComplete, Alert, Radio, Row, Col } from 'antd'
 import { ColorPickerItem } from './color-picker-item.jsx'
 import Password from '../../common/password.jsx'
 import SwitchLabel from '../../common/switch.jsx'
@@ -117,6 +117,42 @@ export function renderFormItem (item, formItemLayout, form, ctxProps, index) {
 
   // Render complex/custom components directly (no extra wrapper component)
   switch (type) {
+    // Puts short fields side by side instead of each on its own line.
+    // Purely presentational: every child is the same field it was before.
+    case 'row':
+      return (
+        <div className='bookmark-form-row' key={name}>
+          {
+            label
+              ? (
+                <div className='bookmark-form-row-label'>
+                  {typeof label === 'function' ? label() : label}
+                </div>
+                )
+              : null
+          }
+          {/* align='bottom' so the controls line up even when one child
+              carries an extra caption line above its input. */}
+          <Row gutter={12} align='bottom'>
+            {
+              (item.children || []).map((child, i) => (
+                <Col key={child.name || i} span={child.span || 12}>
+                  {renderFormItem(child, formItemLayout, form, ctxProps, i)}
+                </Col>
+              ))
+            }
+          </Row>
+        </div>
+      )
+    // A section is only a heading plus a hairline rule: it groups the fields
+    // that follow it without collapsing, persisting state or changing any
+    // field itself.
+    case 'section':
+      return (
+        <div className='bookmark-form-section' key={name}>
+          {typeof label === 'function' ? label() : label}
+        </div>
+      )
     case 'wiki':
       return (
         <Alert

--- a/src/client/components/bookmark-form/common/submit-buttons.jsx
+++ b/src/client/components/bookmark-form/common/submit-buttons.jsx
@@ -40,8 +40,12 @@ export default function SubmitButtons ({
         >
           {e('testConnection')}
         </Button>
+        {/* Outlined, not filled: it stays in the primary colour family so it
+            reads as an exit, but only one button on the row is allowed to be
+            solid or the eye cannot tell which action is the default. */}
         <Button
-          type='primary'
+          color='primary'
+          variant='outlined'
           icon={<CaretRightOutlined />}
           onClick={onConnect}
         >

--- a/src/client/components/bookmark-form/common/submit-buttons.jsx
+++ b/src/client/components/bookmark-form/common/submit-buttons.jsx
@@ -4,6 +4,7 @@
  */
 import React from 'react'
 import { Button, Form } from 'antd'
+import { CaretRightOutlined } from '@ant-design/icons'
 import { tailFormItemLayout } from '../../../common/form-layout'
 
 const FormItem = Form.Item
@@ -17,26 +18,36 @@ export default function SubmitButtons ({
   onSaveAndConnect
 }) {
   return (
-    <FormItem {...tailFormItemLayout}>
-      <p>
-        <Button type='primary' htmlType='submit' className='mg1r mg1b'>
+    <FormItem {...tailFormItemLayout} className='bookmark-form-actions'>
+      <div className='bookmark-form-actions-row'>
+        {/* Save cluster, left. Only one filled button: submitting the form is
+            the action you want almost every time. */}
+        <Button type='primary' htmlType='submit'>
           {e('saveAndConnect')}
         </Button>
-        <Button type='primary' className='mg1r mg1b' onClick={onSaveAndCreateNew}>
+        <Button onClick={onSaveAndCreateNew}>
           {e('saveAndCreateNew')}
         </Button>
-        <Button type='dashed' className='mg1r mg1b' onClick={onSave}>
+        <Button onClick={onSave}>
           {e('save')}
         </Button>
-      </p>
-      <p>
-        <Button type='dashed' onClick={onConnect} className='mg1r mg1b'>
-          {e('connect')}
-        </Button>
-        <Button type='dashed' onClick={onTestConnection} className='mg1r mg1b'>
+        {/* Connect cluster, pushed right. Test connection is a diagnostic, so
+            it carries the least weight of anything here. */}
+        <Button
+          type='text'
+          className='bookmark-form-actions-gap'
+          onClick={onTestConnection}
+        >
           {e('testConnection')}
         </Button>
-      </p>
+        <Button
+          type='primary'
+          icon={<CaretRightOutlined />}
+          onClick={onConnect}
+        >
+          {e('connect')}
+        </Button>
+      </div>
     </FormItem>
   )
 }

--- a/src/client/components/bookmark-form/config/common-fields.js
+++ b/src/client/components/bookmark-form/config/common-fields.js
@@ -328,9 +328,7 @@ export const sshAuthFields = [
   { type: 'switch', name: 'isMFA', label: () => e('MFA/OTP'), valuePropName: 'checked' },
   commonFields.interactiveValues,
 
-  // Space-separated so the missing-key fallback reads as words. translate()
-  // returns the key itself when absent, so 'onConnect' rendered as ONCONNECT.
-  { type: 'section', name: '__sec_onconnect__', label: () => e('on connect') },
+  { type: 'section', name: '__sec_onconnect__', label: () => e('onConnect') },
   commonFields.runScripts,
   commonFields.startDirectoryLocal,
   commonFields.startDirectory,

--- a/src/client/components/bookmark-form/config/common-fields.js
+++ b/src/client/components/bookmark-form/config/common-fields.js
@@ -297,27 +297,45 @@ export const basicAuthFields = [
   commonFields.type
 ]
 
+// Grouped into four sections. No field is added, removed or renamed here --
+// the list is only reordered so related fields sit together under a heading.
 export const sshAuthFields = [
+  { type: 'section', name: '__sec_identity__', label: () => e('identity') },
   commonFields.category,
   commonFields.title,
-  { ...commonFields.host, type: 'sshHostSelector' },
+  // host and port share a line: port is 5 characters wide and does not
+  // deserve a row of its own.
+  {
+    type: 'row',
+    name: '__row_host_port__',
+    label: () => e('host'),
+    children: [
+      { ...commonFields.host, type: 'sshHostSelector', span: 18 },
+      { ...commonFields.port, span: 6 }
+    ]
+  },
   commonFields.username,
+
+  { type: 'section', name: '__sec_auth__', label: () => e('auth') },
   { type: 'sshAuthTypeSelector', name: 'authType', label: '' },
   { type: 'sshAuthSelector', name: '__auth__', label: '', formItemName: 'password' },
-  commonFields.port,
   {
     type: 'sshAgent',
     name: 'useSshAgent'
   },
   { type: 'switch', name: 'isMFA', label: () => e('MFA/OTP'), valuePropName: 'checked' },
+  commonFields.interactiveValues,
+
+  { type: 'section', name: '__sec_onconnect__', label: () => e('onConnect') },
   commonFields.runScripts,
-  commonFields.description,
-  commonFields.setEnv,
   commonFields.startDirectoryLocal,
   commonFields.startDirectory,
-  commonFields.interactiveValues,
+
+  { type: 'section', name: '__sec_env__', label: () => e('environment') },
+  commonFields.setEnv,
   commonFields.envLang,
   commonFields.encode,
+  commonFields.description,
   commonFields.type
 ]
 

--- a/src/client/components/bookmark-form/config/common-fields.js
+++ b/src/client/components/bookmark-form/config/common-fields.js
@@ -310,7 +310,9 @@ export const sshAuthFields = [
     name: '__row_host_port__',
     label: () => e('host'),
     children: [
-      { ...commonFields.host, type: 'sshHostSelector', span: 18 },
+      // Only the host drops its own label -- the row heading already says
+      // "Host". Port keeps its label so its required asterisk stays visible.
+      { ...commonFields.host, type: 'sshHostSelector', span: 18, hideLabel: true },
       { ...commonFields.port, span: 6 }
     ]
   },
@@ -326,7 +328,9 @@ export const sshAuthFields = [
   { type: 'switch', name: 'isMFA', label: () => e('MFA/OTP'), valuePropName: 'checked' },
   commonFields.interactiveValues,
 
-  { type: 'section', name: '__sec_onconnect__', label: () => e('onConnect') },
+  // Space-separated so the missing-key fallback reads as words. translate()
+  // returns the key itself when absent, so 'onConnect' rendered as ONCONNECT.
+  { type: 'section', name: '__sec_onconnect__', label: () => e('on connect') },
   commonFields.runScripts,
   commonFields.startDirectoryLocal,
   commonFields.startDirectory,

--- a/src/client/components/bookmark-form/form-renderer.jsx
+++ b/src/client/components/bookmark-form/form-renderer.jsx
@@ -315,17 +315,23 @@ export default function FormRenderer ({ config, props }) {
   return (
     <Form
       form={form}
+      layout='vertical'
       onFinish={handleFinish}
       initialValues={initialValues}
       name={formName}
+      className='bookmark-form-detail'
     >
-      {content}
-      <SubmitButtons
-        onSave={save}
-        onSaveAndCreateNew={saveAndCreateNew}
-        onConnect={connect}
-        onTestConnection={testConnection}
-      />
+      <div className='bookmark-form-scroll'>
+        {content}
+      </div>
+      <div className='bookmark-form-foot'>
+        <SubmitButtons
+          onSave={save}
+          onSaveAndCreateNew={saveAndCreateNew}
+          onConnect={connect}
+          onTestConnection={testConnection}
+        />
+      </div>
     </Form>
   )
 }

--- a/src/client/components/bookmark-form/index.jsx
+++ b/src/client/components/bookmark-form/index.jsx
@@ -101,7 +101,6 @@ export default class BookmarkIndex2 extends PureComponent {
       <Radio.Group
         buttonStyle='solid'
         size='small'
-        className='mg1l'
         value={bookmarkType}
         disabled={!isNew}
         onChange={this.handleChange}
@@ -130,7 +129,9 @@ export default class BookmarkIndex2 extends PureComponent {
     return (
       <Button
         size='small'
-        className='mg2l create-ai-btn'
+        variant='text'
+        color='default'
+        className='create-ai-btn'
         icon={<RobotOutlined />}
         onClick={this.handleToggleAIMode}
       >
@@ -172,14 +173,19 @@ export default class BookmarkIndex2 extends PureComponent {
     const keys = Object.keys(sessionConfig)
     return (
       <div className='form-wrap pd1x'>
-        <div className='form-title pd1t pd1x pd2b bold'>
+        {/* Two rows: what you are editing on top, how to connect underneath.
+            Nine protocol buttons and a title competing on one line left none
+            of them room to read. */}
+        <div className='form-title pd1t pd1x bold'>
           <BookOutlined className='mg1r' />
           <span>
             {((!isNew ? e('edit') : e('new')) + ' ' + e(settingMap.bookmarks))}
           </span>
           {this.renderTitle(formData, isNew)}
-          {this.renderTypes(bookmarkType, isNew, keys)}
           {this.renderAIButton(isNew)}
+        </div>
+        <div className='form-types pd1x pd2b'>
+          {this.renderTypes(bookmarkType, isNew, keys)}
         </div>
         {this.renderForm()}
       </div>

--- a/src/client/components/bookmark-form/tree-select.jsx
+++ b/src/client/components/bookmark-form/tree-select.jsx
@@ -1,10 +1,10 @@
 import {
   Tree,
   Button,
-  Space,
-  Input
+  Space
 } from 'antd'
 import { useState, useMemo } from 'react'
+import Search from '../common/search'
 import { defaultBookmarkGroupId, settingMap } from '../../common/constants'
 import deepCopy from 'json-deep-copy'
 import createTitle, { createTitleWithTag } from '../../common/create-title'
@@ -164,7 +164,7 @@ export default function BookmarkTreeSelect (props) {
     <div className='tree-select-wrapper pd2'>
       <div className='tree-select-header'>
         <Space.Compact className='mg2b'>
-          <Input.Search
+          <Search
             placeholder={e('search') || 'Search...'}
             value={searchText}
             onChange={(e) => setSearchText(e.target.value)}

--- a/src/client/components/common/search.jsx
+++ b/src/client/components/common/search.jsx
@@ -1,9 +1,22 @@
 /**
- * common search with clear icon
+ * common search box
+ *
+ * Every consumer filters incrementally from onChange, so the submit button
+ * antd's Input.Search renders could never trigger anything that had not
+ * already happened -- pressing it was a no-op. The magnifier moves inside the
+ * field, where it reads as a hint about what the box is for rather than as a
+ * control that does something.
  */
 
 import { Input } from 'antd'
+import { SearchOutlined } from '@ant-design/icons'
 
-const { Search } = Input
-
-export default Search
+export default function Search (props) {
+  return (
+    <Input
+      allowClear
+      prefix={<SearchOutlined className='search-icon-prefix' />}
+      {...props}
+    />
+  )
+}

--- a/src/client/components/quick-commands/quick-commands-box.jsx
+++ b/src/client/components/quick-commands/quick-commands-box.jsx
@@ -5,7 +5,8 @@
 import { useState } from 'react'
 import { quickCommandLabelsLsKey, pinnedQuickCommandBarKey } from '../../common/constants'
 import { sortBy } from 'lodash-es'
-import { Button, Input, Select, Space, Flex } from 'antd'
+import { Button, Select, Space, Flex } from 'antd'
+import Search from '../common/search'
 import * as ls from '../../common/safe-local-storage'
 import CmdItem from './quick-command-item'
 import {
@@ -202,10 +203,10 @@ export default function QuickCommandsFooterBox (props) {
     >
       <div className='pd2'>
         <Flex justify='space-between' className='qm-flex'>
-          <Input.Search
+          <Search
             value={keyword}
             onChange={handleChange}
-            placeholder=''
+            placeholder={`${e('search')} ${e('quickCommands')}`}
             className='qm-search-input'
           />
           <Flex gap='small'>

--- a/src/client/components/setting-panel/list.jsx
+++ b/src/client/components/setting-panel/list.jsx
@@ -58,6 +58,7 @@ export default class ItemList extends React.PureComponent {
         <Search
           onChange={this.handleChange}
           value={this.state.keyword}
+          placeholder={`${e('search')} ${e(this.props.type)}`}
         />
       </div>
     )

--- a/src/client/components/setting-panel/list.styl
+++ b/src/client/components/setting-panel/list.styl
@@ -27,14 +27,19 @@
   margin-bottom 1px
   cursor pointer
   line-height 1.8
+  // Selected rows read as a soft tint plus an accent edge instead of a
+  // full-bleed saturated bar. color-mix keeps this correct for every theme
+  // rather than hardcoding one tint.
+  // unquote() because stylus parses the `in` of color-mix as a unary operator.
   &.active
-    background var(--primary)
-    color var(--primary-contrast)
+    background unquote('color-mix(in srgb, var(--primary) 14%, transparent)')
+    box-shadow inset 2px 0 0 var(--primary)
+    color var(--text-light)
   &.current
     font-weight bold
   &:hover
-    background var(--primary)
-    color var(--primary-contrast)
+    background unquote('color-mix(in srgb, var(--primary) 22%, transparent)')
+    color var(--text-light)
     .list-item-apply
     .list-item-edit
     .list-item-remove

--- a/src/client/components/setting-panel/setting-common.jsx
+++ b/src/client/components/setting-panel/setting-common.jsx
@@ -594,23 +594,42 @@ export default class SettingCommon extends Component {
           this.renderText('keyword2FA')
         }
         {
+          // Same fourteen toggles, same order within each group -- only
+          // grouped under headings so the wall of switches is scannable.
           [
-            'autoRefreshWhenSwitchToSftp',
-            'showHiddenFilesOnSftpStart',
-            'screenReaderMode',
-            'initDefaultTabOnStart',
-            'disableConnectionHistory',
-            'disableTransferHistory',
-            'checkUpdateOnStart',
-            'useSystemTitleBar',
-            'confirmBeforeExit',
-            'hideIP',
-            'allowMultiInstance',
-            'disableDeveloperTool',
-            'switchTabOnHover',
-            'disableShortcutBar',
-            'debug'
-          ].map(this.renderToggle)
+            {
+              title: e('start'),
+              keys: ['initDefaultTabOnStart', 'checkUpdateOnStart']
+            },
+            {
+              title: 'SFTP',
+              keys: ['autoRefreshWhenSwitchToSftp', 'showHiddenFilesOnSftpStart']
+            },
+            {
+              title: e('privacy'),
+              keys: ['disableConnectionHistory', 'disableTransferHistory', 'hideIP']
+            },
+            {
+              title: e('window'),
+              keys: [
+                'useSystemTitleBar',
+                'confirmBeforeExit',
+                'allowMultiInstance',
+                'switchTabOnHover',
+                'disableShortcutBar',
+                'screenReaderMode'
+              ]
+            },
+            {
+              title: e('development'),
+              keys: ['disableDeveloperTool', 'debug']
+            }
+          ].map(group => (
+            <div key={group.title}>
+              <div className='setting-section'>{group.title}</div>
+              {group.keys.map(this.renderToggle)}
+            </div>
+          ))
         }
         {
           window.et.isWebApp ? null : <DeepLinkControl />

--- a/src/client/components/setting-panel/setting-modal.jsx
+++ b/src/client/components/setting-panel/setting-modal.jsx
@@ -5,6 +5,14 @@
 import { auto } from 'manate/react'
 import { pick } from 'lodash-es'
 import { Tabs, Spin } from 'antd'
+import {
+  AppstoreOutlined,
+  BookOutlined,
+  CodeOutlined,
+  PictureOutlined,
+  SettingOutlined,
+  UserOutlined
+} from '@ant-design/icons'
 import { lazy, Suspense } from 'react'
 import SettingModal from './setting-wrap'
 import {
@@ -74,35 +82,44 @@ export default auto(function SettingModalWrap (props) {
         'initLoadingData'
       ])
     }
+    // Icons match the left sidebar rail where an equivalent exists
+    // (bookmarks/setting/terminalThemes/widgets). Quick commands and Profiles
+    // have no rail icon, so they take the repo's usual icon for that concept.
     const items = [
       {
         key: settingMap.bookmarks,
         label: e(settingMap.bookmarks),
+        icon: <BookOutlined />,
         children: null
       },
       {
         key: settingMap.setting,
         label: e(settingMap.setting),
+        icon: <SettingOutlined />,
         children: null
       },
       {
         key: settingMap.terminalThemes,
         label: e('uiThemes'),
+        icon: <PictureOutlined />,
         children: null
       },
       {
         key: settingMap.quickCommands,
         label: e(settingMap.quickCommands),
+        icon: <CodeOutlined />,
         children: null
       },
       {
         key: settingMap.profiles,
         label: e(settingMap.profiles),
+        icon: <UserOutlined />,
         children: null
       },
       {
         key: settingMap.widgets,
         label: <>{e(settingMap.widgets)} <sup>Beta</sup></>,
+        icon: <AppstoreOutlined />,
         children: null
       }
     ]

--- a/src/client/components/setting-panel/setting-wrap.styl
+++ b/src/client/components/setting-panel/setting-wrap.styl
@@ -23,9 +23,12 @@
   left 0
   width 340px
   bottom 0
-  padding 20px 0 20px 20px
+  padding 20px 20px 20px 20px
   display flex
   flex-direction column
+  // Divider between the list column and the detail column. The column edge
+  // does more for hierarchy than any amount of spacing.
+  border-right 1px solid var(--main-light)
   .model-bookmark-tree-wrap
     flex 1
     display flex

--- a/src/client/components/setting-panel/setting-wrap.styl
+++ b/src/client/components/setting-panel/setting-wrap.styl
@@ -15,9 +15,15 @@
 .batch-op-wrap .close-setting-wrap
   top 40px
   right 30px
+// The tab strip ends at 97px. Ant gives its nav a 16px bottom margin which is
+// dead space here, so it is removed and both columns start just under the
+// strip -- and at the SAME y, which they previously did not (127 vs 129).
+.setting-tabs > .ant-tabs-nav
+  margin-bottom 0
+
 .setting-row
   position absolute
-  top 127px
+  top 105px
   overflow-y scroll
 .setting-row-left
   left 0
@@ -39,7 +45,7 @@
   left 340px
   right 0
   bottom 0
-  top 129px
+  top 105px
   padding 20px
   display flex
   flex-direction column
@@ -71,6 +77,11 @@
   ::-webkit-scrollbar
     width 0
 @media (max-width: 1100px)
+  // The six tab icons add ~130px to the nav strip, which is exactly enough to
+  // push the last tabs off screen on a narrow window. The label is the
+  // function; the icon is decoration, so the icon is what gives way.
+  .setting-tabs .ant-tabs-tab-icon
+    display none
   .setting-col
     position fixed
     top 128px

--- a/src/client/components/setting-panel/setting-wrap.styl
+++ b/src/client/components/setting-panel/setting-wrap.styl
@@ -21,13 +21,23 @@
 .setting-tabs > .ant-tabs-nav
   margin-bottom 0
 
+// The list column's width and the detail column's left offset have to be the
+// same number. They were two hardcoded values kept in sync by hand, and they
+// had drifted: the bookmarks override said 483px, which is 440 + 43, adding
+// the icon rail a second time even though .setting-col is already offset by
+// it. That left a 43px gap between the divider and the detail column in
+// Bookmarks and none anywhere else. One variable now feeds both, so they
+// cannot disagree again.
+.setting-wrap
+  --list-col-width 340px
+
 .setting-row
   position absolute
   top 105px
   overflow-y scroll
 .setting-row-left
   left 0
-  width 340px
+  width var(--list-col-width)
   bottom 0
   padding 20px 20px 20px 20px
   display flex
@@ -42,10 +52,9 @@
     overflow hidden
     min-height 0
 .setting-row-right
-  left 340px
+  left var(--list-col-width)
   right 0
   bottom 0
-  top 105px
   padding 20px
   display flex
   flex-direction column
@@ -61,11 +70,9 @@
   justify-content flex-end
   .carbonads-wrap
     margin 8px 0 0
+// Bookmarks needs a wider list column: it shows a nested tree, not a flat list.
 .setting-tabs-bookmarks
-  .setting-row-left
-    width 440px
-  .setting-row-right
-    left 483px
+  --list-col-width 440px
 .setting-tabs
   position absolute
   z-index 4

--- a/src/client/components/setting-panel/setting-wrap.styl
+++ b/src/client/components/setting-panel/setting-wrap.styl
@@ -64,6 +64,20 @@
   flex 1
   overflow-y auto
   min-height 0
+  // Each tab wraps its content in a helper that carries its own inset -- pd1x
+  // is 5px, pd2x is 16px, some bring none -- so the distance from the divider
+  // to the first control changed from tab to tab, and so did the distance
+  // from the top. The pane's own padding is the only one that should count.
+  > .form-wrap
+  > .ant-form
+  > .item-list
+    padding-left 0
+    padding-right 0
+    padding-top 0
+  > .form-wrap > .form-title
+    padding-left 0
+    padding-right 0
+    padding-top 0
 .setting-col-placeholder
   flex-shrink 0
   display flex

--- a/src/client/components/setting-panel/setting-wrap.styl
+++ b/src/client/components/setting-panel/setting-wrap.styl
@@ -84,7 +84,9 @@
     display none
   .setting-col
     position fixed
-    top 128px
+    // Matches the desktop columns. The tab strip ends at 97px, and this pane
+    // already clears it -- the old 128px predates removing antd's nav margin.
+    top 105px
     bottom 0
     left var(--left-side-bar-width, 43px)
     right 0
@@ -96,7 +98,9 @@
     left auto
     width auto
     bottom auto
-    padding 138px 10px 10px 10px
+    // .setting-col is already offset below the tab strip, so this top padding
+    // was clearing it a second time -- ~160px of dead space above the tree.
+    padding 10px
   .setting-row-right
     left auto
     right auto

--- a/src/client/components/setting-panel/setting.styl
+++ b/src/client/components/setting-panel/setting.styl
@@ -1,3 +1,15 @@
+// Heading plus hairline for the toggle groups in Setting. Matches
+// .bookmark-form-section; kept local so each panel styles itself.
+.setting-section
+  margin 26px 0 14px
+  padding-bottom 6px
+  border-bottom 1px solid var(--main-light)
+  color var(--text-dark)
+  font-size 12px
+  font-weight 600
+  letter-spacing .05em
+  text-transform uppercase
+
 .pd2b.bg-img-setting
   display inline-block
   padding 0

--- a/src/client/components/tree-list/tree-list.styl
+++ b/src/client/components/tree-list/tree-list.styl
@@ -44,6 +44,12 @@
       color var(--text-light)
   &.item-dragover-top
     border 2px solid var(--primary)
+// A folder with no children renders no expander. The missing caret alone is
+// too quiet a signal, so an empty folder also reads dimmer.
+.tree-list-row:not(:has(.tree-expander))
+  .tree-item.is-category .tree-item-title
+    opacity .5
+
 .tree-item-title
   flex-grow 1
   line-height 26px
@@ -107,6 +113,20 @@
 
 .tree-list-header
   flex-shrink 0
+  // The search row is an inline-block, so it collapsed to its content width
+  // and left roughly half the column unused. Let it fill the pane instead.
+  .tree-sort-wrap
+    display block
+    .ant-space-compact
+      width 100%
+      align-items stretch
+      // The search wrapper renders 4px taller than the buttons beside it, so
+      // the row had two different bottom edges. Pin every child to the theme's
+      // control height instead of hardcoding a number.
+      > *
+        height var(--ant-control-height)
+      .ant-input-affix-wrapper, .ant-input-wrapper, .ant-input
+        height 100%
 
 .item-list-wrap
   flex 1

--- a/src/client/components/tree-list/tree-list.styl
+++ b/src/client/components/tree-list/tree-list.styl
@@ -16,19 +16,32 @@
   overflow hidden
   white-space nowrap
   text-overflow ellipsis
+  // Folder headers read as quieter, smaller labels than the bookmarks they
+  // contain, so the hierarchy is legible without indentation alone.
   &.is-category
     .tree-item-title
-      font-weight bold
-      font-size 14px
+      font-weight 600
+      font-size 12px
+      letter-spacing .02em
+      color var(--text-dark)
 
   &.search-selected
     outline 1px dashed var(--primary)
+  // Hover is a faint wash; selection is a soft tint plus a 2px accent edge,
+  // instead of the previous full-bleed solid bar.
+  &:hover
+    background rgba(255, 255, 255, .055)
+    color var(--text-light)
+    cursor pointer
   &.selected
   &.item-dragover
-  &:hover
-    background #000
-    color #eee
+    background unquote('color-mix(in srgb, var(--primary) 14%, transparent)')
+    box-shadow inset 2px 0 0 var(--primary)
+    color var(--text-light)
     cursor pointer
+  &.selected.is-category
+    .tree-item-title
+      color var(--text-light)
   &.item-dragover-top
     border 2px solid var(--primary)
 .tree-item-title

--- a/src/client/components/tree-list/tree-search.jsx
+++ b/src/client/components/tree-list/tree-search.jsx
@@ -82,6 +82,7 @@ export default memo(function TreeSearchComponent ({
           value={searchTerm}
           allowClear
           autoFocus={autoFocus}
+          placeholder={`${window.translate('search')} ${window.translate('bookmarks')}`}
         />
         <Button
           className={`tree-sort-trigger pointer${isSortActive ? ' active' : ''}`}

--- a/src/client/components/widgets/widgets-list.jsx
+++ b/src/client/components/widgets/widgets-list.jsx
@@ -3,9 +3,9 @@
  */
 import React, { useState, useEffect } from 'react'
 import {
-  Input,
   Tabs
 } from 'antd'
+import Search from '../common/search'
 import WidgetInstances from './widget-instances'
 import classnames from 'classnames'
 import highlight from '../common/highlight'
@@ -90,9 +90,9 @@ export default auto(function WidgetsList ({ activeItemId, store }) {
     return (
       <div className='item-list item-type-widgets'>
         <div className='pd1y'>
-          <Input.Search
+          <Search
             type='text'
-            placeholder='Search widgets...'
+            placeholder={`${e('search')} ${e('widgets')}`}
             value={keyword}
             onChange={handleSearch}
             className='form-control'

--- a/src/client/css/basic.styl
+++ b/src/client/css/basic.styl
@@ -4,7 +4,7 @@
 body
   overflow hidden
   background var(--main)
-  font-size 12px
+  font-size 13px
   line-height 1.5715
   font-family -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'
   font-variant: tabular-nums

--- a/src/client/store/store.js
+++ b/src/client/store/store.js
@@ -268,7 +268,11 @@ class Store {
         colorWarning: themeConf.warn,
         colorTextBase: themeConf.text,
         colorLink: themeConf['text-light'],
-        motion: false
+        fontSize: 13,
+        controlHeight: 34,
+        motionDurationFast: '0.1s',
+        motionDurationMid: '0.14s',
+        motionDurationSlow: '0.2s'
       },
       algorithm: isColorDark(themeConf.main) ? theme.darkAlgorithm : theme.defaultAlgorithm
     }

--- a/src/client/store/store.js
+++ b/src/client/store/store.js
@@ -270,9 +270,7 @@ class Store {
         colorLink: themeConf['text-light'],
         fontSize: 13,
         controlHeight: 34,
-        motionDurationFast: '0.1s',
-        motionDurationMid: '0.14s',
-        motionDurationSlow: '0.2s'
+        motion: false
       },
       algorithm: isColorDark(themeConf.main) ? theme.darkAlgorithm : theme.defaultAlgorithm
     }


### PR DESCRIPTION
## What this is

A visual pass over the settings overlay and the bookmark editor. No new features,
no new screens, no changes to the data model, storage format, sync payload or any
user-facing string.

I'd been using electerm daily and kept bumping into the same small things, mostly in
the bookmark editor, so I sat down and measured them instead of just grumbling. Most
of what's here is either a token value or moving existing markup around.

Happy to split this further, drop any part of it, or close it if the direction isn't
what you want for the project. I tried to keep every commit independently revertable
so you can take some of it and leave the rest.

*Before*
<img width="1400" height="880" alt="BEFORE-1400" src="https://github.com/user-attachments/assets/42b70f1a-1f3a-4b1d-a47c-6028bf229fa0" />

*After*
<img width="1400" height="880" alt="AFTER-1400" src="https://github.com/user-attachments/assets/9094e555-cc4c-4787-a660-f437ef3dcfc0" />

## The measurements

All taken from the running app at 1440px, not estimated:

| | before | after |
|---|---|---|
| Label channel in the bookmark form | 611px, right-aligned, mostly empty | 0, labels sit on top |
| Distance from divider to first control | 48px on Bookmarks, 36px on Setting, varied per tab | 20px everywhere |
| Two columns start at | left 127px, right 129px | both 105px |
| Search field in the tree | 186px inside a 399px column | fills the column |
| Save button | at the end of a ~1300px scroll | pinned to the bottom |

The label channel one is the reason I started. `formItemLayout` in
`src/client/common/form-layout.js` sets `labelCol: sm 8 / wrapperCol: sm 16`, so a
third of the pane was reserved for right-aligned labels. With top labels every field
shares one left edge, and the form fits in less vertical space too.

## What changed, roughly in order

**Type scale.** `body` was 12px while antd components were 14px, two scales in the
same UI. Both are 13px now.

**Motion stays off.** I did turn antd transitions on at one point, since they're all
disabled and nothing documents why. Then I talked myself out of it: disabled
transitions are a reasonable call in a terminal emulator, and no comment explaining
something isn't evidence it was an oversight. Reverted, so this PR is layout and
spacing only. The commit is still there if you ever want it.

**Corner radius stays at 3px.** I tried 6px and it fought the icon set, which is
square. Reverted.

**Forms.** Labels on top via the shared `form-layout.js`. That file is imported by 37
components, so this also flips the profile, VNC, RDP and widget forms. I did that on
purpose, because leaving some forms with side labels and others without looks like a
bug rather than a deliberate boundary, but it is the widest-reaching change here and
the easiest one to argue with.

**Bookmark editor.** The field list scrolls with the sub-tab bar pinned at the top and
the actions pinned at the bottom. Fields are grouped under four headings (Identity,
Auth, On connect, Environment). No field is added, removed or renamed, the list is
only reordered. Host and port share a row, since port is five characters wide.

**Setting.** The fourteen toggles are grouped under five headings instead of one
undifferentiated wall.

**Column offsets.** `.setting-tabs-bookmarks .setting-row-right` said `left: 483px`,
which is `440 + 43`, the icon rail counted twice, since `.setting-col` is already
offset by it. That left a 43px gap between the divider and the detail column on
Bookmarks and none on any other tab. Both the width and the offset now come from one
`--list-col-width` variable so they can't drift apart again.

**Below 1100px.** The stacked layout had a few problems: the footer never pinned, and
there was a horizontal overflow. Both came from the same thing. Rules written with
`:has()` outrank the plain-class rules inside the media query, so a media query alone
didn't undo them and an inner scroller stayed alive. Also `.setting-row-left` reserved
138px of top padding to clear the tab strip that `.setting-col` already clears, which
was about 160px of dead space above the tree.

*Before*
<img width="1000" height="800" alt="BEFORE-1000" src="https://github.com/user-attachments/assets/6d10c73a-c033-4127-93aa-26797aad44f3" />

*After*
<img width="1000" height="800" alt="AFTER-1000" src="https://github.com/user-attachments/assets/c0f4c335-fc3b-4937-999c-d35b02aa3d74" />


## One thing you should know before merging

The four section headings in the bookmark form and the five in Setting use these keys:

```
identity   on connect   environment   start   privacy   development
```

**None of them exist in `@electerm/electerm-locales`.** I checked all 15 locale files.
`auth` and `window` do exist and resolve fine. `translate()` falls back to the key
itself, so in Chinese, Japanese, Russian and the rest, those headings render as
English words mixed in with the translated ones.

Six of the seven happen to read as correct English through that fallback. The seventh
didn't: `onConnect` came out as `ONCONNECT` under the uppercase transform, which is
why it's written `on connect` in the config.

I'm opening a PR against `electerm-locales` with the six keys. This PR will still show
English headings in other languages until that one lands and the dependency here is
bumped. If you'd rather not merge this until that's sorted, that's completely fair, or
I can pull the headings out of this PR and add them back afterwards.

## Testing

I drove the running app over CDP and measured computed styles and element geometry
rather than eyeballing screenshots, which is how I caught the 2px column
misalignment and the 43px gap. Neither is visible by looking.

Checked at 1532px, 1200px, 1000px and 760px. `npm run lint` passes. Verified the six
overlay tabs still fit at narrow widths (the icons hide below 1100px, since six of
them add about 130px to the nav strip and pushed the last tabs off screen).

Rebased onto master at 5.1.20. One conflict, in `setting-common.jsx`, where you'd
added `disableShortcutBar` to the toggle list and I'd restructured that list into
groups. It's in the Window group now.

