### PR TITLE
Quote the electron-rebuild path in post-install

### DIFF
--- a/build/bin/post-install.js
+++ b/build/bin/post-install.js
@@ -35,7 +35,10 @@ try {
   console.warn('Failed to remove cpu-features:', e?.message || e)
 }
 
-exec(resolve('./node_modules/.bin/electron-rebuild'))
+// Quoted, because this resolves to an absolute path and is handed to a shell.
+// An unquoted path containing a space is split into separate arguments, so the
+// rebuild never runs on a checkout under e.g. C:\Users\me\Project Code\electerm.
+exec(`"${resolve(__dirname, '../../node_modules/.bin/electron-rebuild')}"`)
 
 if (!existsSync(prePushPath)) {
   cp(prePushPathFrom, prePushPath)


### PR DESCRIPTION
## The problem

`build/bin/post-install.js` builds an absolute path to `electron-rebuild` and hands it
to a shell without quoting it. If the checkout lives anywhere with a space in the path,
the shell splits the path and the rebuild never runs.

I hit this on a clone under `C:\Users\me\Documents\Project Code\electerm`. Here are the
two forms side by side on that same path:

```
without quotes   'C:\Users\me\Documents\Project' is not recognized as an
                 internal or external command                        exit 1

with quotes      Usage: electron-rebuild --version [version]
                 --module-dir [path]                                 exit 0
```

It fails quietly. `npm install` still reports success, and you only find out later when
a native module doesn't load.

## The change

Quotes the path. Also resolves it from `__dirname` instead of the working directory,
which is what every other path in the file already does (`prePushPath`,
`cpuFeaturesPaths`). The old form worked only because npm happens to run postinstall
from the package root.

That second part is slightly beyond the title, so pull it out if you'd rather keep the
diff to the quoting alone.

## Testing

The two runs above are the test: same binary, same path, quoted and unquoted. `npm run
lint` passes.

Windows is where this bites, since `Program Files` and `My Documents` style paths are
normal there, but the quoting is correct on any platform.
