### PR TITLE
Fix terminal render partial area on fullscreen cross-display dpr change

### DIFF
--- a/src/client/components/terminal/terminal.jsx
+++ b/src/client/components/terminal/terminal.jsx
@@ -137,6 +137,8 @@ class Term extends Component {
     this.currentInput = ''
     this.shellInjected = false
     this.shellType = null
+    // dpr 基线：跨屏全屏时用于检测 dpr 变化，见 onResize。
+    this._lastDpr = window.devicePixelRatio
   }
 
   domRef = createRef()
@@ -2036,6 +2038,25 @@ class Term extends Component {
   }
 
   onResize = throttle(() => {
+    const dpr = window.devicePixelRatio
+    // 跨屏全屏（外接屏 dpr=1 ↔ 内建 Retina dpr=2）时，Electron 的
+    // window.devicePixelRatio 更新与 xterm 内部 ScreenDprMonitor
+    // （matchMedia resolution 监听）存在时序竞态：若全屏切换先触发
+    // resize 事件、后更新 dpr，ScreenDprMonitor 会把旧 dpr 记为
+    // current，之后真正的 dpr 变化被 miss。渲染器内部 _devicePixelRatio
+    // 停在旧值，gl.viewport 只覆盖部分画布，表现为终端只渲染一部分
+    // 区域（canvas 其余透明露出主题背景）。
+    // 检测到 dpr 变化即重建 WebGL renderer，强制用新 dpr 重建 viewport
+    // 与字符 atlas，从根上消除该竞态。
+    if (this._lastDpr !== dpr) {
+      this._lastDpr = dpr
+      if (
+        this.props.config.rendererType === rendererTypes.webGL &&
+        this.webglAddon
+      ) {
+        this.reloadWebglRenderer('dpr change')
+      }
+    }
     this.fitAndRefresh()
   }, 200)
 


### PR DESCRIPTION
### 问题

macOS 系统原生全屏下，SSH 会话偶发只渲染屏幕的一部分（通常为上半部分或左上角一小块），其余区域透出主题背景色。该问题只在跨显示器全屏时出现，且不操作会一直保持异常，需要重新进入全屏才能恢复。

### 原因

跨屏全屏（如外接屏 dpr=1 ↔ 内建 Retina dpr=2）时，Electron 的 `window.devicePixelRatio` 更新与 xterm 内部 `ScreenDprMonitor`（基于 `matchMedia('resolution')` 的监听）存在时序竞态：若全屏切换先触发 resize 事件、后更新 dpr，`ScreenDprMonitor` 会把旧 dpr 记为当前值，之后真正的 dpr 变化被 miss。渲染器内部的 `_devicePixelRatio` 因此停留在旧值，`gl.viewport` 只覆盖部分画布 —— canvas 物理尺寸虽由 ResizeObserver 正确修正，但绘制视口未同步，导致终端只渲染一部分区域，其余画布透明露出主题背景。

### 修复

在 `Term.onResize`（throttle 200ms）中检测 `window.devicePixelRatio` 是否变化：一旦检测到 dpr 变化，即重建 WebGL renderer（复用现有 `reloadWebglRenderer` 机制），强制以新 dpr 重建 `gl.viewport` 与字符 atlas，从根上消除该竞态。仅作用于 WebGL 渲染模式，DOM 渲染不受影响。

### 验证

- 在 arm64 macOS（Electron 42.8.1）本地构建并打包验证：外接屏与内建屏之间反复全屏切换、反复进入/退出全屏，SSH 会话始终铺满全屏，不再出现只渲染部分区域的现象。
- 变更仅涉及 `src/client/components/terminal/terminal.jsx`，共 21 行。