### PR TITLE
Fix terminal size stuck wrong after tab reload/reconnect

### DIFF
--- a/src/client/components/terminal/terminal.jsx
+++ b/src/client/components/terminal/terminal.jsx
@@ -1940,6 +1940,17 @@ class Term extends Component {
     if (this.isElementVisible()) {
       this.fitAddon.fit()
     }
+    // Force-send the current size now that `this.pid` is finally valid.
+    // A resize may already have fired earlier (e.g. from the tab-becomes-
+    // visible fit in componentDidUpdate, which can run before createTerm()
+    // resolves) while this.pid was still undefined - the backend silently
+    // drops resize calls for an unknown pid. If that earlier call already
+    // updated term.cols/rows locally, xterm's resize() no-ops on the next
+    // fit() (dims unchanged) and never fires onResize again, so the
+    // backend pty would otherwise be stuck at its initial (possibly wrong)
+    // size forever. Sending explicitly here, keyed off the real pid,
+    // guarantees the remote pty/ssh channel is told the true current size.
+    resizeTerm(this.pid, term.cols, term.rows)
     term.displayRaw = displayRaw
     term.loadAddon(
       new KeywordHighlighterAddon(keywords)

--- a/src/client/store/tab.js
+++ b/src/client/store/tab.js
@@ -111,17 +111,22 @@ export default Store => {
     // Remove old tab
     tabs.splice(index, 1)
 
-    setTimeout(() => {
-      if (store.activeTabId === tabId) {
-        store.activeTabId = newTab.id
-      }
+    // Update active tab id synchronously (same as addTab) so the new tab's
+    // container is already visible (display:block) by the time its Terminal
+    // mounts. Deferring this via setTimeout(0) left the container hidden at
+    // mount time, causing the initial fit()/createTerm() to use xterm's
+    // default 80x24 size instead of the real fitted size - which then got
+    // baked into the remote pty and only partially corrected later, leaving
+    // full-screen apps like tmux/vim rendering at the wrong size.
+    if (store.activeTabId === tabId) {
+      store.activeTabId = newTab.id
+    }
 
-      // Update batch current tab ID if needed
-      const batchProp = `activeTabId${oldBatch}`
-      if (store[batchProp] === tabId) {
-        store[batchProp] = newTab.id
-      }
-    }, 0)
+    // Update batch current tab ID if needed
+    const batchProp = `activeTabId${oldBatch}`
+    if (store[batchProp] === tabId) {
+      store[batchProp] = newTab.id
+    }
   }
 
   Store.prototype.reloadAllTabs = function () {


### PR DESCRIPTION
## Bug

After disconnecting an SSH session in a tab (without closing it) and reconnecting via the tab's **reload** button, the remote terminal size can get stuck wrong — full-screen apps like `tmux`/`vim` render at the wrong size (e.g. only filling half the window), even though the local xterm.js viewport itself looks correctly sized. Closing the tab and opening a brand-new connection does not reproduce this.

## Root cause

Two things compound into one race:

1. **`reloadTab()` deferred the active-tab-id update.** `Store.prototype.reloadTab` (in `src/client/store/tab.js`) spliced the new tab into `tabs` synchronously, but only updated `activeTabId`/`activeTabId<batch>` inside a `setTimeout(0)` — unlike `addTab()`, which updates them synchronously before the new tab ever mounts.

   Since a tab's container is styled `display:none` until its id matches `activeTabId<batch>` (see `session.styl`), the new `Terminal` component mounted while its container was still hidden. `terminal.jsx`'s `initTerminal()` deliberately skips the initial `fitAddon.fit()` while hidden (to avoid computing 0 columns), so `remoteInit()` read `term.cols`/`term.rows` while they were still at xterm.js's construction-time default (~80x24) and shipped that stale size to `createTerm(opts)` — which is what spawns the actual remote pty.

2. **A corrective resize could be silently dropped.** Once the tab became visible, `componentDidUpdate`'s `shouldChange` branch scheduled a corrective `fitAndRefresh()`. Because `createTerm()` is a real network/SSH round trip, this corrective fit often resolved *before* `this.pid` was assigned in `remoteInit()`, so the resize it triggered went out as `resizeTerm(undefined, cols, rows)`. Server-side, `session-api.js`'s `resize()` does `terminals(pid)` and silently no-ops if the terminal isn't found — no error anywhere. Once `this.pid` became valid, a later `fitAddon.fit()` computed the *same* cols/rows (already updated locally by the earlier, wasted attempt), so xterm.js's `resize()` no-op'd and never fired `onResize` again — meaning the one resize call with a *valid* pid never got sent. The backend pty was left stuck at the original wrong size.

## Fix

- **`src/client/store/tab.js`**: `reloadTab()` now updates `activeTabId`/`activeTabId<batch>` synchronously, matching `addTab()`. The new tab's container is already visible by the time it mounts, so the initial fit and `createTerm()` get the correct size from the start.
- **`src/client/components/terminal/terminal.jsx`**: `remoteInit()` now explicitly calls `resizeTerm(this.pid, term.cols, term.rows)` once `this.pid` is valid, guaranteeing the backend is told the true current size even if an earlier resize attempt was dropped due to the pid race.

## Verification

Full Electron GUI e2e testing wasn't available in the sandbox this was developed in (no display server), so both fixes were verified directly against the real, unmodified project code instead of reimplementations:

- **`tab.js`**: bundled the actual `reloadTab`/`addTab` functions (stubbing only unrelated UI/asset imports) against a minimal fake store. Confirmed `activeTabId` now updates synchronously after `reloadTab()`. A negative-control run against the pre-fix code reproduced the original (deferred) behavior, confirming the test is a real discriminator.
- **`terminal.jsx`**: ran the real `session-api.js` → `session.js` → `session-local.js` against a live `node-pty` process. Confirmed `resize({ pid: undefined, ... })` is silently dropped (reproducing the bug) and `resize({ pid: <real>, ... })` correctly updates the pty's actual OS-level window size (confirming the fix).

`npm run lint` (via `standard`) passes clean on both changed files and the full `src` tree.

I'd still recommend a manual sanity check on a real machine (disconnect → reload → reconnect → open tmux/vim) before merging, since I could not do that pixel-level check myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
