### PR TITLE
Fix RDP sessions dropping after ~15s of idle activity

### DIFF
--- a/src/app/server/rdp-proxy.js
+++ b/src/app/server/rdp-proxy.js
@@ -432,6 +432,19 @@ async function performRDPHandshake (host, port, x224Request, options = {}) {
         connected: function (connection) {
           log.debug(`${logPrefix} ✓ node-forge TLS handshake completed`)
 
+          // The handshake-deadline timer set below (in the outer function)
+          // is a `net.Socket` idle-inactivity timer, not a one-shot deadline
+          // - it re-arms on every read/write and was never cleared once the
+          // handshake finished. Left alone, it destroys this same socket
+          // (reused for the whole session relay) after any 15s stretch with
+          // no bytes in either direction - e.g. a static remote desktop with
+          // no mouse/keyboard activity - killing otherwise-healthy sessions.
+          // Disable it now that the handshake is done; a real dead/half-open
+          // connection is instead caught by the TCP keepalive enabled below.
+          tcpSocket.setTimeout(0)
+          tcpSocket.setNoDelay(true)
+          tcpSocket.setKeepAlive(true, 10000)
+
           // Step 5: Convert captured certificates to DER
           const certChain = forgeCertsToDer(capturedCertChain)
           log.debug(`${logPrefix} ✓ Extracted ${certChain.length} certificate(s) from forge`)


### PR DESCRIPTION
## Bug

RDP sessions intermittently disconnect/freeze - the tab has to be closed and the bookmark reopened, or the tab reloaded, to reconnect. This can happen even on connections that are otherwise healthy (tested across both LAN-ish and higher-latency/VPN-tunneled paths).

## Root cause

`performRDPHandshake()` in `src/app/server/rdp-proxy.js` sets a 15-second timer on the TCP socket, intended as a handshake deadline:

```js
tcpSocket.setTimeout(15000, () => {
  tcpSocket.destroy()
  settle(new Error('Connection timed out'))
})
```

`net.Socket#setTimeout()` is **not** a one-shot deadline - it's an idle-inactivity timer that re-arms on every read/write and fires whenever the socket has gone that long with *no* bytes in either direction. It was set once before the handshake and never cleared afterward, and the very same socket is reused for the entire session relay (`setupForgeRelay`).

**Effect:** any time the RDP TCP connection went 15+ seconds without a single byte in either direction - e.g. a static remote desktop with no mouse/keyboard activity - the backend silently destroyed the connection. This can happen on any network (VPN or not), but is more likely to surface on higher-latency/jittery paths (e.g. IPSEC tunnels) where natural gaps in traffic more easily exceed 15s.

Compounding the symptom: unlike SSH tabs, RDP has no keepalive and no auto-reconnect (`scheduleAutoReconnect` only exists for SSH terminals in `terminal.jsx`), so when this fires the only visible feedback is a frozen canvas and a small error dot on the tab - there's no automatic recovery and no clear "disconnected" indicator, which is exactly the "session breaks, I have to reload" experience being reported.

## Fix

In the TLS `connected` callback (i.e. once the handshake has actually completed):

- `tcpSocket.setTimeout(0)` - disables the idle-destroy timer for the live relay. A real dead/half-open connection is instead caught by the keepalive below, rather than punishing a session that's simply idle but healthy.
- `tcpSocket.setKeepAlive(true, 10000)` - real TCP-level keepalive, so a genuinely dead connection (cable pulled, VPN drop) is still detected - matching what SSH sessions already get via ssh2's keepalive.
- `tcpSocket.setNoDelay(true)` - same `TCP_NODELAY` tuning SSH sessions already have (`session-ssh.js`), disabling Nagle's algorithm for lower input latency.

## Testing

- `npm run lint` (`standard`) passes clean on the changed file and the full `src` tree (also enforced by this repo's own `pre-push` hook).
- Built a full local Linux package with this patch (`electron-builder` → `tar.gz`) and confirmed the packaged `app.asar` contains the fix.
- **Real-world validation**: ran the patched build against RDP sessions to two different machines with different connection latencies, continuously, for ~2-3 hours. No disconnects or freezes were observed with the patch applied, on connections that previously dropped intermittently without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
